### PR TITLE
fix: desabilita cache interno do flutter-action no workflow de release

### DIFF
--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Flutter SDK (com cache interno)
+      # Flutter SDK
       - name: Flutter
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.32.0'
           channel: stable
-          cache: true
+          cache: false
 
       # 💾 Cache do Pub (Dart/Flutter packages)
       - name: Cache Pub


### PR DESCRIPTION
Corrige erro 'hashFiles failed' no workflow de release:
- Muda cache: true para cache: false no flutter-action

O cache interno tenta fazer hash do pubspec.lock antes do checkout estar completo, causando falha no workflow.