### PR TITLE
fix: Use Fastlane lane for API key authentication when fetching build…

### DIFF
--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -101,8 +101,8 @@ jobs:
           APP_STORE_CONNECT_API_KEY_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_PRIVATE_KEY }}
           BUNDLE_ID: ${{ env.BUNDLE_ID }}
         run: |
-          NEXT_BUILD=$(bundle exec fastlane run latest_testflight_build_number app_identifier:"$BUNDLE_ID" | grep -oE 'Result: [0-9]+' | grep -oE '[0-9]+')
-          NEXT_BUILD=$((NEXT_BUILD + 1))
+          bundle exec fastlane get_next_build_number
+          NEXT_BUILD=$(cat ../next_build_number.txt)
           echo "Next build number: $NEXT_BUILD"
           echo "BUILD_NUMBER=$NEXT_BUILD" >> $GITHUB_OUTPUT
 

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,9 @@ GoogleService-Info.plist
 /ios/fastlane/metadata/review_information/
 /ios/ExportOptions.plist
 
+# Generated during CI
+next_build_number.txt
+
 # Flutter
 .flutter-plugins
 .flutter-plugins-dependencies

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -28,6 +28,7 @@ Runner/GeneratedPluginRegistrant.*
 # Generated during CI
 ExportOptions.plist
 GoogleService-Info.plist
+next_build_number.txt
 
 # Exceptions to above rules.
 !default.mode1v3

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,6 +1,23 @@
 default_platform(:ios)
 
 platform :ios do
+  desc "Retorna o próximo build number (último do TestFlight + 1)"
+  lane :get_next_build_number do
+    app_store_connect_api_key(
+      key_id: ENV['APP_STORE_CONNECT_API_KEY_ID'],
+      issuer_id: ENV['APP_STORE_CONNECT_API_KEY_ISSUER_ID'],
+      key_content: ENV['APP_STORE_CONNECT_API_KEY_PRIVATE_KEY']
+    )
+
+    current = latest_testflight_build_number(app_identifier: ENV['BUNDLE_ID'])
+    next_build = current + 1
+    UI.message("Current build: #{current}, Next build: #{next_build}")
+
+    # Escreve o número em um arquivo para o CI ler
+    File.write("../next_build_number.txt", next_build.to_s)
+    next_build
+  end
+
   desc "Build + upload para TestFlight (sem match)"
   lane :beta do
     app_store_connect_api_key(


### PR DESCRIPTION
… number

- Create get_next_build_number lane that properly authenticates with App Store Connect API
- Update workflow to use the new lane instead of direct fastlane run command
- Add next_build_number.txt to gitignore (generated during CI)