### PR TITLE
fix: Parse build number from Fastlane output instead of file

### DIFF
--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -101,8 +101,8 @@ jobs:
           APP_STORE_CONNECT_API_KEY_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_PRIVATE_KEY }}
           BUNDLE_ID: ${{ env.BUNDLE_ID }}
         run: |
-          bundle exec fastlane get_next_build_number
-          NEXT_BUILD=$(cat ../next_build_number.txt)
+          OUTPUT=$(bundle exec fastlane get_next_build_number)
+          NEXT_BUILD=$(echo "$OUTPUT" | grep -oE 'Next build: [0-9]+' | grep -oE '[0-9]+')
           echo "Next build number: $NEXT_BUILD"
           echo "BUILD_NUMBER=$NEXT_BUILD" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The File.write in Fastlane wasn't creating the file in the expected location. Now we capture the Fastlane output and parse the build number directly.