### PR TITLE
fix: Use Flutter build with correct build number in Fastlane

### DIFF
--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -91,59 +91,8 @@ jobs:
           /usr/bin/plutil -lint GoogleService-Info.plist
           echo "GoogleService-Info.plist criado em ios/"
 
-      # 🔢 Busca o último build number do TestFlight e incrementa
-      - name: Get next build number
-        id: build_number
-        working-directory: ios
-        env:
-          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_PRIVATE_KEY }}
-          BUNDLE_ID: ${{ env.BUNDLE_ID }}
-        run: |
-          OUTPUT=$(bundle exec fastlane get_next_build_number)
-          NEXT_BUILD=$(echo "$OUTPUT" | grep -oE 'Next build: [0-9]+' | grep -oE '[0-9]+')
-          echo "Next build number: $NEXT_BUILD"
-          echo "BUILD_NUMBER=$NEXT_BUILD" >> $GITHUB_OUTPUT
-
-      # 📄 Gera ExportOptions.plist para o Flutter build
-      - name: Generate ExportOptions.plist
-        env:
-          BUNDLE_ID: ${{ env.BUNDLE_ID }}
-        run: |
-          cat > ios/ExportOptions.plist <<PLIST
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>method</key>
-              <string>app-store</string>
-              <key>teamID</key>
-              <string>$DEVELOPMENT_TEAM</string>
-              <key>signingStyle</key>
-              <string>manual</string>
-              <key>provisioningProfiles</key>
-              <dict>
-                  <key>$BUNDLE_ID</key>
-                  <string>$PROFILE_NAME</string>
-              </dict>
-              <key>uploadSymbols</key>
-              <true/>
-          </dict>
-          </plist>
-          PLIST
-          echo "ExportOptions.plist created with TEAM=$DEVELOPMENT_TEAM"
-
-      # 🏗️ Flutter build com build number incrementado
-      - name: Flutter build IPA
-        run: |
-          flutter build ipa \
-            --release \
-            --build-number=${{ steps.build_number.outputs.BUILD_NUMBER }} \
-            --export-options-plist=ios/ExportOptions.plist
-
-      # 🚀 Upload para TestFlight via Fastlane
-      - name: Fastlane upload
+      # 🚀 Build + upload via Fastlane (incrementa build number automaticamente)
+      - name: Fastlane beta
         working-directory: ios
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -155,7 +104,7 @@ jobs:
           PROFILE_NAME: ${{ env.PROFILE_NAME }}
           FASTLANE_SKIP_UPDATE_CHECK: "true"
           CI: "true"
-        run: bundle exec fastlane upload
+        run: bundle exec fastlane beta
 
       - name: Upload fastlane logs (on failure)
         if: failure()

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -26,10 +26,15 @@ platform :ios do
       key_content: ENV['APP_STORE_CONNECT_API_KEY_PRIVATE_KEY']
     )
 
-    # numeração do build (ex.: última + 1)
-    increment_build_number(
-      build_number: latest_testflight_build_number + 1
-    )
+    # Busca o próximo build number
+    current_build = latest_testflight_build_number(app_identifier: ENV['BUNDLE_ID'])
+    next_build = current_build + 1
+    UI.message("Current build: #{current_build}, Next build: #{next_build}")
+
+    # 🏗️ Flutter build com build number correto (sem code sign)
+    Dir.chdir("..") do
+      sh("flutter", "build", "ios", "--release", "--no-codesign", "--build-number=#{next_build}")
+    end
 
     # 🔧 força assinatura só no Runner (Release)
     update_code_signing_settings(
@@ -43,7 +48,7 @@ platform :ios do
       profile_uuid: ENV['PROFILE_UUID']    # opcional, ajuda a fixar
     )
 
-    # 🏗️ archive + export (sem passar PROVISIONING_* em xcargs)
+    # 🏗️ archive + export
     build_app(
       workspace: "Runner.xcworkspace",
       scheme: "Runner",
@@ -56,7 +61,6 @@ platform :ios do
           ENV['BUNDLE_ID'] => ENV['PROFILE_NAME']
         }
       },
-      # xcargs mínimos: time/team, sem perfis
       xcargs: "DEVELOPMENT_TEAM=#{ENV['DEVELOPMENT_TEAM']} CODE_SIGN_STYLE=Manual"
     )
 


### PR DESCRIPTION
- Add flutter build ios --no-codesign --build-number=X before xcodebuild
- This ensures the correct build number is used (from TestFlight + 1)
- Simplified workflow to use single fastlane beta command