### PR TITLE
refactor: redesenha tela de OS seguindo Apple HIG

### DIFF
--- a/lib/screens/forms/form_fill_screen.dart
+++ b/lib/screens/forms/form_fill_screen.dart
@@ -301,6 +301,51 @@ class _FormFillScreenState extends State<FormFillScreen> {
     }
   }
 
+  /// Verifica se todos os campos obrigatórios foram preenchidos
+  bool _isFormComplete() {
+    for (final item in _currentForm.items) {
+      if (!item.required) continue;
+
+      final response = _currentForm.getResponse(item.id);
+
+      if (item.type == FormItemType.photoOnly) {
+        if (response == null || response.photoUrls.isEmpty) return false;
+      } else {
+        if (response == null || response.value == null || response.value.toString().isEmpty) return false;
+      }
+    }
+    return true;
+  }
+
+  /// Lida com o fechamento da tela, auto-concluindo se estiver completo
+  Future<void> _handleClose() async {
+    // Se já está concluído ou não está completo, apenas fecha
+    if (_currentForm.status == FormStatus.completed || !_isFormComplete()) {
+      Navigator.pop(context);
+      return;
+    }
+
+    // Formulário completo mas não marcado como concluído - auto-concluir
+    setState(() => _isSaving = true);
+
+    try {
+      await _formsService.updateStatus(
+        widget.companyId,
+        widget.orderId,
+        _currentForm.id,
+        FormStatus.completed
+      );
+      HapticFeedback.mediumImpact();
+    } catch (e) {
+      // Se falhar, apenas fecha sem concluir
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+        Navigator.pop(context, true);
+      }
+    }
+  }
+
   Future<void> _reopenForm() async {
     setState(() => _isSaving = true);
 
@@ -440,8 +485,8 @@ class _FormFillScreenState extends State<FormFillScreen> {
             largeTitle: Text(_currentForm.title),
             leading: CupertinoButton(
               padding: EdgeInsets.zero,
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Cancelar'),
+              onPressed: _handleClose,
+              child: const Text('Fechar'),
             ),
             trailing: _isSaving
                 ? const CupertinoActivityIndicator()

--- a/lib/screens/widgets/order_photos_widget.dart
+++ b/lib/screens/widgets/order_photos_widget.dart
@@ -59,22 +59,11 @@ class OrderPhotosWidget extends StatelessWidget {
   }
 
   Widget _buildPhotosGrid(BuildContext context, SegmentConfigProvider config) {
-    return Column(
-      children: [
-        // Foto de capa (primeira foto)
-        if (store.photos.isNotEmpty) 
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: _buildCoverPhoto(context, config),
-          ),
-        const SizedBox(height: 8),
-        // Grid das outras fotos
-        if (store.photos.length > 1) 
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: _buildThumbnailGrid(context, config),
-          ),
-      ],
+    if (store.photos.isEmpty) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      child: _buildCoverPhoto(context, config),
     );
   }
 
@@ -144,49 +133,6 @@ class OrderPhotosWidget extends StatelessWidget {
           ),
         ],
       ),
-    );
-  }
-
-  Widget _buildThumbnailGrid(BuildContext context, SegmentConfigProvider config) {
-    final thumbnailPhotos = store.photos.skip(1).toList();
-
-    return GridView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      padding: EdgeInsets.zero,
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 3,
-        crossAxisSpacing: 8,
-        mainAxisSpacing: 8,
-      ),
-      itemCount: thumbnailPhotos.length,
-      itemBuilder: (context, index) {
-        final photo = thumbnailPhotos[index];
-        final actualIndex = index + 1; // +1 porque pulamos a primeira foto
-
-        return GestureDetector(
-          onTap: () => _showPhotoViewer(context, actualIndex, config),
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: CachedImage(
-                  imageUrl: photo.url!,
-                  fit: BoxFit.cover,
-                  borderRadius: BorderRadius.circular(8),
-                  memCacheWidth: 200, // Otimiza para thumbnails
-                ),
-              ),
-              Positioned(
-                top: 4,
-                right: 4,
-                child: _buildPhotoActionButton(context, actualIndex, config, small: true),
-              ),
-            ],
-          ),
-        );
-      },
     );
   }
 


### PR DESCRIPTION
## Summary
- Reorganiza seções da tela de OS por prioridade prática (cliente/dispositivo primeiro)
- Implementa layout seguindo Apple Human Interface Guidelines (listas agrupadas)
- Adiciona indicadores visuais de status nos checklists (verde=concluído, laranja=pendente)
- Bloqueia conclusão da OS quando há checklists pendentes
- Auto-conclui formulários quando completamente preenchidos
- Simplifica exibição de fotos (apenas capa, sem thumbnails)

## Test plan
- [ ] Verificar nova ordem das seções na tela de OS
- [ ] Testar alteração de status para "Concluído" com checklists pendentes (deve bloquear)
- [ ] Testar auto-conclusão do formulário ao fechar com todos campos preenchidos
- [ ] Verificar exibição da foto de capa e badge de contagem
- [ ] Validar indicadores visuais dos checklists (verde/laranja)

🤖 Generated with [Claude Code](https://claude.com/claude-code)