### PR TITLE
Bold total value for paid work orders

### DIFF
--- a/lib/screens/menu_navigation/home.dart
+++ b/lib/screens/menu_navigation/home.dart
@@ -426,7 +426,7 @@ class _HomeState extends State<Home> {
                                     style: TextStyle(
                                       fontSize: 15,
                                       color: CupertinoColors.secondaryLabel.resolveFrom(context),
-                                      fontWeight: FontWeight.w400,
+                                      fontWeight: order.payment == 'paid' ? FontWeight.bold : FontWeight.w400,
                                     ),
                                   ),
                                   const SizedBox(width: 8),


### PR DESCRIPTION
Altera o fontWeight do valor total na listagem de OS para negrito quando order.payment == 'paid', facilitando a identificação visual das ordens que já foram pagas.