### PR TITLE
fix: corrige criação de empresa no onboarding e adiciona model Membership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,227 @@
+# CLAUDE.md - Instruções para Claude Code
+
+Este documento fornece contexto e diretrizes para Claude Code trabalhar no projeto PraticOS.
+
+## Projeto
+
+**PraticOS** - Sistema de gestão de ordens de serviço (OS) desenvolvido em Flutter com Firebase.
+
+### Stack Principal
+- **Flutter** (versão no `.fvmrc`, usar FVM)
+- **Firebase**: Firestore, Auth, Storage
+- **MobX**: Gerenciamento de estado reativo
+- **Fastlane**: Automação de deploy (iOS/Android)
+
+### Arquitetura em Camadas
+
+```
+UI Layer (Screens/Widgets)       → lib/screens/
+State Management (MobX)          → lib/mobx/
+Business Logic (Repositories)    → lib/repositories/
+Data Models (JSON Serializable)  → lib/models/
+External Services                → lib/services/
+```
+
+### Fluxo de Dados
+
+```
+Firebase (Backend)
+    ↓
+Repositories (TenantRepository/RepositoryV2)
+    ↓
+Stores (MobX - estado reativo)
+    ↓
+UI Screens (Observer widgets)
+```
+
+## Comandos Essenciais
+
+```bash
+# Gerar código MobX/JSON (OBRIGATÓRIO após alterar Stores/Models)
+fvm flutter pub run build_runner build --delete-conflicting-outputs
+
+# Watch mode para desenvolvimento
+fvm flutter pub run build_runner watch
+
+# Análise de código
+fvm flutter analyze
+```
+
+## Estrutura de Pastas
+
+```
+lib/
+├── main.dart                    # Entry point, rotas, Firebase init
+├── global.dart                  # Estado global (currentUser, companyAggr)
+├── models/                      # Modelos de dados
+│   ├── base.dart               # Classe base (id)
+│   ├── base_audit.dart         # Campos de auditoria
+│   ├── base_audit_company.dart # Multi-tenancy
+│   └── *.g.dart                # Arquivos gerados (JSON)
+├── mobx/                        # Stores MobX
+│   └── *.g.dart                # Arquivos gerados (MobX)
+├── repositories/                # Camada de dados
+│   ├── tenant/                 # TenantRepository (subcollections)
+│   └── repository.dart         # Base genérica
+├── screens/                     # Telas UI
+│   ├── customers/              # Módulo clientes
+│   ├── dashboard/              # Dashboard financeiro
+│   ├── menu_navigation/        # Navegação principal
+│   └── widgets/                # Widgets reutilizáveis
+└── services/                    # Serviços externos
+    ├── photo_service.dart      # Firebase Storage
+    └── auth_service.dart       # Autenticação
+```
+
+## Multi-Tenancy
+
+O sistema usa isolamento por empresa (tenant). **Toda operação deve considerar o companyId**.
+
+### Estrutura de Permissões
+- **Path**: `/companies/{companyId}/roles/{roleId}`
+- **Gerenciamento**: `CollaboratorStore` + `RoleRepositoryV2`
+
+### Onde aplicar `companyId`:
+1. **Models**: Herdar de `BaseAuditCompany` (campo `company`)
+2. **Repositories**: Usar `TenantRepository` ou filtrar com `QueryArgs('company.id', companyId)`
+3. **Stores**: Atribuir `entity.company = Global.companyAggr`
+4. **Storage**: Path `tenants/{companyId}/orders/{orderId}/photos/`
+
+## Padrões de Código
+
+### Modelos (Full + Aggregate)
+
+Cada entidade tem DUAS classes:
+
+```dart
+// Classe completa - todos os campos
+@JsonSerializable(explicitToJson: true)
+class Customer extends BaseAuditCompany {
+  String? name;
+  // ... todos os campos
+  CustomerAggr toAggr() => _$CustomerAggrFromJson(this.toJson());
+}
+
+// Classe agregada - campos essenciais (para embedar em outros docs)
+@JsonSerializable()
+class CustomerAggr {
+  String? id;
+  String? name;
+}
+```
+
+### Stores MobX
+
+```dart
+import 'package:mobx/mobx.dart';
+part 'customer_store.g.dart';
+
+class CustomerStore = _CustomerStore with _$CustomerStore;
+
+abstract class _CustomerStore with Store {
+  final CustomerRepository repository = CustomerRepository();
+
+  @observable
+  ObservableStream<List<Customer>>? customerList;
+
+  @action
+  Future<void> load() async { ... }
+}
+```
+
+### Repositories
+
+Prefira `TenantRepository` para novas features:
+
+```dart
+class CustomerRepository extends TenantRepository<Customer> {
+  // Automaticamente acessa /companies/{companyId}/customers/
+}
+```
+
+## UX/UI Guidelines
+
+### App (iOS/Cupertino-first)
+
+**Widgets obrigatórios:**
+- `CupertinoPageScaffold` + `CupertinoSliverNavigationBar`
+- `CupertinoListSection.insetGrouped` para formulários
+- `CupertinoAlertDialog` para confirmações
+- `CupertinoActionSheet` para menus/opções
+- `CupertinoSearchTextField` para busca
+
+**Dark Mode - Cores dinâmicas:**
+```dart
+// CORRETO - usar .resolveFrom(context)
+color: CupertinoColors.label.resolveFrom(context)
+
+// ERRADO - não adapta ao dark mode
+color: CupertinoColors.label
+```
+
+**Cores que REQUEREM `.resolveFrom(context)`:**
+- `CupertinoColors.label`, `secondaryLabel`
+- `CupertinoColors.systemBackground`, `systemGroupedBackground`
+- `CupertinoColors.systemGrey`, `systemGrey5`
+- `CupertinoColors.separator`
+
+**Cores estáticas (não precisam de resolução):**
+- `CupertinoColors.white`, `black`
+- `CupertinoColors.activeBlue`, `systemRed`, `systemGreen`
+
+**Status Indicators:**
+- Usar dots coloridos (8-10px) em vez de badges pesados
+- Azul = Novo/Aprovado, Verde = Concluído, Vermelho = Problema
+
+### Web (Dark Premium Theme)
+
+- Background: `#0A0E17` (deep blue/black)
+- Gradients para CTAs
+- Glassmorphism para navegação
+- Fonte: `Outfit` (headings), `DM Sans` (body)
+
+## Formulários Dinâmicos
+
+Sistema de checklists e vistorias personalizados.
+
+**Templates:** `/companies/{companyId}/form_templates/{formId}`
+**Instâncias:** `/companies/{companyId}/orders/{orderId}/forms/{instanceId}`
+**Fotos:** `tenants/{companyId}/orders/{orderId}/forms/{instanceId}/items/{itemId}/`
+
+## Deploy
+
+### Android (Play Store)
+```bash
+cd android
+bundle exec fastlane internal           # Internal track
+bundle exec fastlane deploy_with_metadata  # Com metadados
+bundle exec fastlane promote_to_production
+```
+
+### iOS (App Store)
+```bash
+cd ios
+bundle exec fastlane beta               # TestFlight
+bundle exec fastlane release_store      # App Store
+```
+
+### CI/CD
+- **Push master**: Deploy para trilhas internas (Internal/TestFlight)
+- **Tag `v*`**: Deploy para produção
+
+## Regras Importantes
+
+1. **Multi-Tenancy é Prioridade**: Sempre verificar estrutura de company/roles
+2. **Build Runner**: Executar após alterar Stores/Models
+3. **AuthService**: Usar para criar novos usuários (não gravar direto no banco)
+4. **CollaboratorStore**: Usar para gerenciar membros da equipe (não usar CompanyStore)
+5. **Cupertino-first**: App deve parecer nativo iOS
+6. **Dark Mode**: Sempre usar `.resolveFrom(context)` para cores dinâmicas
+
+## Documentação Adicional
+
+- `docs/UX_GUIDELINES.md` - Padrões visuais iOS/Cupertino
+- `docs/WEB_UX_GUIDELINES.md` - Padrões para site institucional
+- `docs/MULTI_TENANCY.md` - Detalhes da arquitetura multi-tenant
+- `docs/formularios_dinamicos.md` - Especificação de checklists/vistorias
+- `docs/DEPLOYMENT.md` - Guia completo de deploy

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -196,10 +196,16 @@ service cloud.firestore {
         allow read, write: if belongsToCompany(companyId);
       }
 
-      match /memberships/{userId} {
+      match /memberships/{memberId} {
         allow read: if belongsToCompany(companyId);
-        // Owner ou admins podem gerenciar memberships
-        allow write: if request.auth != null
+        // Permite criar seu próprio membership (signup) ou owner/admin gerenciar outros
+        allow create: if request.auth != null
+          && (
+            request.auth.uid == memberId  // Self-membership (signup)
+            || isCompanyAdmin(companyId)
+          );
+        // Update/delete apenas owner ou admin
+        allow update, delete: if request.auth != null
           && (
             get(/databases/$(database)/documents/companies/$(companyId)).data.owner.id == request.auth.uid
             || isCompanyAdmin(companyId)

--- a/lib/mobx/auth_store.dart
+++ b/lib/mobx/auth_store.dart
@@ -40,7 +40,7 @@ abstract class _AuthStore with Store {
       await userStore.createUserIfNotExist(user);
 
       var dbUser = await userStore.findUserById(user.uid);
-      Company company;
+      Company? company;
 
       // Check if there is a last selected company saved
       String? lastCompanyId = prefs.getString('companyId');
@@ -71,6 +71,13 @@ abstract class _AuthStore with Store {
       prefs.setString('userEmail', user.email ?? '');
       if (user.photoURL != null) {
         prefs.setString('userPhoto', user.photoURL!);
+      }
+
+      // Se não encontrou empresa, usuário vai para onboarding
+      if (company == null) {
+        companyAggr = null;
+        Global.companyAggr = null;
+        return;
       }
 
       if (company.id != null) {
@@ -110,7 +117,7 @@ abstract class _AuthStore with Store {
 
     // Busca o usuário atualizado do Firestore
     var dbUser = await userStore.findUserById(user.uid);
-    Company company;
+    Company? company;
 
     // Check if there is a last selected company saved
     String? lastCompanyId = prefs.getString('companyId');
@@ -132,6 +139,13 @@ abstract class _AuthStore with Store {
     } else {
       // Fallback for legacy or owner-only logic
       company = await companyStore.getCompanyByOwnerId(user.uid);
+    }
+
+    // Se não encontrou empresa, mantém null
+    if (company == null) {
+      companyAggr = null;
+      Global.companyAggr = null;
+      return;
     }
 
     if (company.id != null) {

--- a/lib/mobx/auth_store.g.dart
+++ b/lib/mobx/auth_store.g.dart
@@ -55,6 +55,18 @@ mixin _$AuthStore on _AuthStore, Store {
     return _$switchCompanyAsyncAction.run(() => super.switchCompany(companyId));
   }
 
+  late final _$reloadUserAndCompanyAsyncAction = AsyncAction(
+    '_AuthStore.reloadUserAndCompany',
+    context: context,
+  );
+
+  @override
+  Future<void> reloadUserAndCompany() {
+    return _$reloadUserAndCompanyAsyncAction.run(
+      () => super.reloadUserAndCompany(),
+    );
+  }
+
   late final _$signOutGoogleAsyncAction = AsyncAction(
     '_AuthStore.signOutGoogle',
     context: context,

--- a/lib/mobx/collaborator_store.dart
+++ b/lib/mobx/collaborator_store.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:mobx/mobx.dart';
 import 'package:praticos/global.dart';
 import 'package:praticos/models/invite.dart';
+import 'package:praticos/models/membership.dart';
 import 'package:praticos/models/user_role.dart';
 import 'package:praticos/repositories/invite_repository.dart';
 import 'package:praticos/repositories/tenant/tenant_membership_repository.dart';
@@ -208,9 +209,8 @@ abstract class _CollaboratorStore with Store {
           userId: user.id!,
           user: user.toAggr(),
           role: roleType,
-          joinedAt: DateTime.now(),
         );
-        batch.set(membershipRef, membership.toJson());
+        batch.set(membershipRef, membership.toFirestore());
       }
 
       // 4. Commit atômico (mesmo que ambos já existam, não faz mal)

--- a/lib/mobx/collaborator_store.g.dart
+++ b/lib/mobx/collaborator_store.g.dart
@@ -98,7 +98,9 @@ mixin _$CollaboratorStore on _CollaboratorStore, Store {
 
   @override
   Future<void> loadPendingInvites() {
-    return _$loadPendingInvitesAsyncAction.run(() => super.loadPendingInvites());
+    return _$loadPendingInvitesAsyncAction.run(
+      () => super.loadPendingInvites(),
+    );
   }
 
   late final _$addCollaboratorAsyncAction = AsyncAction(

--- a/lib/mobx/company_store.dart
+++ b/lib/mobx/company_store.dart
@@ -23,8 +23,10 @@ abstract class _CompanyStore with Store {
         as FutureOr<Company?>);
   }
 
-  Future<Company> getCompanyByOwnerId(String id) async {
-    return await repository.getSingleQuery([QueryArgs('owner.id', id)]);
+  Future<Company?> getCompanyByOwnerId(String id) async {
+    final companies = await repository.getQueryList(args: [QueryArgs('owner.id', id)]);
+    if (companies.isEmpty) return null;
+    return companies.first;
   }
 
   @action

--- a/lib/mobx/invite_store.dart
+++ b/lib/mobx/invite_store.dart
@@ -2,9 +2,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:mobx/mobx.dart';
 import 'package:praticos/global.dart';
 import 'package:praticos/models/invite.dart';
+import 'package:praticos/models/membership.dart';
 import 'package:praticos/models/user_role.dart';
 import 'package:praticos/repositories/invite_repository.dart';
-import 'package:praticos/repositories/tenant/tenant_membership_repository.dart';
 import 'package:praticos/repositories/user_repository.dart';
 
 part 'invite_store.g.dart';
@@ -114,9 +114,8 @@ abstract class _InviteStore with Store {
         userId: userId,
         user: user.toAggr(),
         role: role,
-        joinedAt: DateTime.now(),
       );
-      batch.set(membershipRef, membership.toJson());
+      batch.set(membershipRef, membership.toFirestore());
 
       // 3c. Atualiza status do convite
       final inviteRef = _db.collection('invites').doc(invite.id);

--- a/lib/mobx/invite_store.g.dart
+++ b/lib/mobx/invite_store.g.dart
@@ -13,9 +13,9 @@ mixin _$InviteStore on _InviteStore, Store {
 
   @override
   bool get hasPendingInvites => (_$hasPendingInvitesComputed ??= Computed<bool>(
-        () => super.hasPendingInvites,
-        name: '_InviteStore.hasPendingInvites',
-      )).value;
+    () => super.hasPendingInvites,
+    name: '_InviteStore.hasPendingInvites',
+  )).value;
 
   late final _$pendingInvitesAtom = Atom(
     name: '_InviteStore.pendingInvites',
@@ -78,7 +78,9 @@ mixin _$InviteStore on _InviteStore, Store {
 
   @override
   Future<void> loadPendingInvites() {
-    return _$loadPendingInvitesAsyncAction.run(() => super.loadPendingInvites());
+    return _$loadPendingInvitesAsyncAction.run(
+      () => super.loadPendingInvites(),
+    );
   }
 
   late final _$acceptInviteAsyncAction = AsyncAction(

--- a/lib/mobx/user_store.dart
+++ b/lib/mobx/user_store.dart
@@ -61,10 +61,14 @@ abstract class _UserStore with Store {
   /// Cria uma empresa para o usuário atual (usado no onboarding).
   Future<void> createCompanyForUser(Company company) async {
     final userId = Global.currentUser?.uid;
-    if (userId == null) return;
+    if (userId == null) {
+      throw Exception('Usuário não autenticado');
+    }
 
     User? user = await repository.findUserById(userId);
-    if (user == null) return;
+    if (user == null) {
+      throw Exception('Usuário não encontrado no Firestore');
+    }
 
     // Adiciona a empresa à lista do usuário
     CompanyRoleAggr companyRole = CompanyRoleAggr()

--- a/lib/mobx/user_store.g.dart
+++ b/lib/mobx/user_store.g.dart
@@ -34,6 +34,16 @@ mixin _$UserStore on _UserStore, Store {
     return _$findCurrentUserAsyncAction.run(() => super.findCurrentUser());
   }
 
+  late final _$findUserByIdAsyncAction = AsyncAction(
+    '_UserStore.findUserById',
+    context: context,
+  );
+
+  @override
+  Future<User?> findUserById(String userId) {
+    return _$findUserByIdAsyncAction.run(() => super.findUserById(userId));
+  }
+
   @override
   String toString() {
     return '''

--- a/lib/models/invite.g.dart
+++ b/lib/models/invite.g.dart
@@ -22,14 +22,14 @@ Invite _$InviteFromJson(Map<String, dynamic> json) => Invite()
   ..status = $enumDecodeNullable(_$InviteStatusEnumMap, json['status']);
 
 Map<String, dynamic> _$InviteToJson(Invite instance) => <String, dynamic>{
-      'id': instance.id,
-      'email': instance.email,
-      'company': instance.company?.toJson(),
-      'role': _$RolesTypeEnumMap[instance.role],
-      'invitedBy': instance.invitedBy?.toJson(),
-      'createdAt': instance.createdAt?.toIso8601String(),
-      'status': _$InviteStatusEnumMap[instance.status],
-    };
+  'id': instance.id,
+  'email': instance.email,
+  'company': instance.company?.toJson(),
+  'role': _$RolesTypeEnumMap[instance.role],
+  'invitedBy': instance.invitedBy?.toJson(),
+  'createdAt': instance.createdAt?.toIso8601String(),
+  'status': _$InviteStatusEnumMap[instance.status],
+};
 
 const _$RolesTypeEnumMap = {
   RolesType.admin: 'admin',

--- a/lib/models/membership.dart
+++ b/lib/models/membership.dart
@@ -1,0 +1,78 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:praticos/models/user.dart';
+import 'package:praticos/models/user_role.dart';
+
+part 'membership.g.dart';
+
+/// Conversor customizado para Timestamp do Firestore
+class TimestampConverter implements JsonConverter<DateTime?, dynamic> {
+  const TimestampConverter();
+
+  @override
+  DateTime? fromJson(dynamic json) {
+    if (json == null) return null;
+    if (json is Timestamp) return json.toDate();
+    if (json is String) return DateTime.parse(json);
+    return null;
+  }
+
+  @override
+  dynamic toJson(DateTime? date) {
+    if (date == null) return FieldValue.serverTimestamp();
+    return Timestamp.fromDate(date);
+  }
+}
+
+/// Modelo para membership (índice reverso de colaboradores por empresa).
+///
+/// Path: `/companies/{companyId}/memberships/{userId}`
+///
+/// Esta collection serve como índice para listar rapidamente os colaboradores
+/// de uma empresa. O source of truth é `user.companies`.
+@JsonSerializable(explicitToJson: true)
+class Membership {
+  /// ID do usuário (também é o ID do documento)
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  String? userId;
+
+  /// Dados resumidos do usuário
+  UserAggr? user;
+
+  /// Papel do usuário na empresa
+  RolesType? role;
+
+  /// Data de entrada na empresa
+  @TimestampConverter()
+  DateTime? joinedAt;
+
+  Membership({
+    this.userId,
+    this.user,
+    this.role,
+    this.joinedAt,
+  });
+
+  factory Membership.fromJson(Map<String, dynamic> json) =>
+      _$MembershipFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MembershipToJson(this);
+
+  /// Factory para criar a partir de documento do Firestore
+  factory Membership.fromFirestore(String odId, Map<String, dynamic> json) {
+    final membership = Membership.fromJson(json);
+    membership.userId = odId;
+    return membership;
+  }
+
+  /// Converte para Map incluindo FieldValue.serverTimestamp() para joinedAt
+  Map<String, dynamic> toFirestore() {
+    return {
+      'user': user?.toJson(),
+      'role': role?.name,
+      'joinedAt': joinedAt != null
+          ? Timestamp.fromDate(joinedAt!)
+          : FieldValue.serverTimestamp(),
+    };
+  }
+}

--- a/lib/models/membership.g.dart
+++ b/lib/models/membership.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'membership.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Membership _$MembershipFromJson(Map<String, dynamic> json) => Membership(
+  user: json['user'] == null
+      ? null
+      : UserAggr.fromJson(json['user'] as Map<String, dynamic>),
+  role: $enumDecodeNullable(_$RolesTypeEnumMap, json['role']),
+  joinedAt: const TimestampConverter().fromJson(json['joinedAt']),
+);
+
+Map<String, dynamic> _$MembershipToJson(Membership instance) =>
+    <String, dynamic>{
+      'user': instance.user?.toJson(),
+      'role': _$RolesTypeEnumMap[instance.role],
+      'joinedAt': const TimestampConverter().toJson(instance.joinedAt),
+    };
+
+const _$RolesTypeEnumMap = {
+  RolesType.admin: 'admin',
+  RolesType.manager: 'manager',
+  RolesType.user: 'user',
+};

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -19,13 +19,26 @@ class AuthRepository {
   }
 
   Future<User> signInWithGoogle() async {
+    // Desconecta sessão anterior para permitir escolher outra conta
+    // Isso é especialmente útil no simulador iOS
+    try {
+      await _googleSignIn.disconnect();
+    } catch (_) {
+      // Ignora erro se não havia sessão anterior
+    }
+
     final GoogleSignInAccount? googleSignInAccount =
         await (_googleSignIn.signIn());
-    final GoogleSignInAuthentication? googleSignInAuthentication =
-        await googleSignInAccount?.authentication;
+
+    if (googleSignInAccount == null) {
+      throw Exception('Login cancelado pelo usuário');
+    }
+
+    final GoogleSignInAuthentication googleSignInAuthentication =
+        await googleSignInAccount.authentication;
     final AuthCredential credential = GoogleAuthProvider.credential(
-      accessToken: googleSignInAuthentication?.accessToken,
-      idToken: googleSignInAuthentication?.idToken,
+      accessToken: googleSignInAuthentication.accessToken,
+      idToken: googleSignInAuthentication.idToken,
     );
     final UserCredential authResult =
         await _auth.signInWithCredential(credential);

--- a/lib/screens/menu_navigation/collaborator_list_screen.dart
+++ b/lib/screens/menu_navigation/collaborator_list_screen.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart' show Colors, Material, MaterialType, Divi
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:praticos/mobx/collaborator_store.dart';
 import 'package:praticos/models/invite.dart';
+import 'package:praticos/models/membership.dart';
 import 'package:praticos/models/user_role.dart';
-import 'package:praticos/repositories/tenant/tenant_membership_repository.dart';
 
 class CollaboratorListScreen extends StatefulWidget {
   @override
@@ -383,7 +383,7 @@ class _CollaboratorListScreenState extends State<CollaboratorListScreen> {
     if (!canManage) return content;
 
     return Dismissible(
-      key: Key(membership.userId),
+      key: Key(membership.userId!),
       direction: DismissDirection.horizontal,
       background: Container(
         color: CupertinoColors.systemBlue,
@@ -464,7 +464,7 @@ class _CollaboratorListScreenState extends State<CollaboratorListScreen> {
               Navigator.pop(context);
               try {
                 await _collaboratorStore.updateCollaboratorRole(
-                    membership.userId, role);
+                    membership.userId!, role);
               } catch (e) {
                 _showError(e.toString());
               }
@@ -496,7 +496,7 @@ class _CollaboratorListScreenState extends State<CollaboratorListScreen> {
             onPressed: () async {
               Navigator.pop(context);
               try {
-                await _collaboratorStore.removeCollaborator(membership.userId);
+                await _collaboratorStore.removeCollaborator(membership.userId!);
               } catch (e) {
                 _showError(e.toString());
               }


### PR DESCRIPTION
## Summary

- Corrige bug onde novos usuários não conseguiam criar empresa no onboarding ("Empresa não foi salva corretamente no Firestore")
- Corrige crash ao iniciar app com usuário sem empresa (RangeError)
- Corrige problema de troca de conta Google no simulador iOS
- Cria model `Membership` próprio seguindo padrão do projeto

## Mudanças

### Firestore Rules
- Adiciona regra de **self-membership** para permitir que usuário crie seu próprio membership durante signup
- Separa regras de `create` e `update/delete` para memberships

### Correções de Bug
- `company_store.getCompanyByOwnerId()` agora retorna `null` em vez de crashar com lista vazia
- `auth_store` lida corretamente com usuários sem empresa (redireciona para onboarding)
- `auth_repository.signInWithGoogle()` chama `disconnect()` antes de `signIn()` para permitir trocar de conta

### Novo Model
- `lib/models/membership.dart` com `@JsonSerializable` e `TimestampConverter`
- Refatora `tenant_membership_repository` para usar o novo model

### Documentação
- Adiciona `CLAUDE.md` com instruções para Claude Code

## Test Plan

- [ ] Criar novo usuário e verificar que o onboarding funciona
- [ ] Clicar em "Configurar Depois" e verificar que empresa padrão é criada
- [ ] Verificar que usuários existentes continuam funcionando
- [ ] Testar troca de conta Google no simulador iOS
- [ ] Fazer deploy das Firestore Rules: `cd firebase && firebase deploy --only firestore:rules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)