### PR TITLE
docs: add user profiles documentation section to website

### DIFF
--- a/firebase/hosting/public/docs/docs.css
+++ b/firebase/hosting/public/docs/docs.css
@@ -1,0 +1,972 @@
+/* ============================================
+   PráticOS - Documentation Styles
+   ============================================ */
+
+/* Docs Hero Section */
+.docs-hero {
+    padding: 140px 0 60px;
+    position: relative;
+    overflow: hidden;
+    background: var(--bg-secondary);
+}
+
+.docs-hero.compact {
+    padding: 120px 0 40px;
+}
+
+.docs-hero .hero-bg {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.docs-hero .gradient-orb {
+    opacity: 0.2;
+}
+
+.docs-hero .orb-1 {
+    width: 400px;
+    height: 400px;
+    top: -150px;
+    right: -100px;
+}
+
+.docs-hero .orb-2 {
+    width: 300px;
+    height: 300px;
+    bottom: -100px;
+    left: -100px;
+}
+
+.docs-hero-content {
+    position: relative;
+    z-index: 1;
+    max-width: 700px;
+}
+
+.docs-hero h1 {
+    font-size: clamp(2rem, 4vw, 3rem);
+    margin-bottom: 16px;
+}
+
+.docs-hero .hero-subtitle {
+    font-size: 1.125rem;
+    color: var(--text-secondary);
+    line-height: 1.7;
+    margin-bottom: 0;
+}
+
+/* Breadcrumb */
+.docs-breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+    font-size: 0.875rem;
+}
+
+.docs-breadcrumb a {
+    color: var(--color-primary-light);
+}
+
+.docs-breadcrumb a:hover {
+    text-decoration: underline;
+}
+
+.docs-breadcrumb span {
+    color: var(--text-tertiary);
+}
+
+/* Search Box */
+.docs-search {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-full);
+    padding: 14px 24px;
+    max-width: 500px;
+    margin-top: 32px;
+    transition: var(--transition-fast);
+}
+
+.docs-search:focus-within {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(74, 155, 217, 0.2);
+}
+
+.docs-search svg {
+    color: var(--text-tertiary);
+    flex-shrink: 0;
+}
+
+.docs-search input {
+    background: transparent;
+    border: none;
+    outline: none;
+    font-family: var(--font-body);
+    font-size: 1rem;
+    color: var(--text-primary);
+    width: 100%;
+}
+
+.docs-search input::placeholder {
+    color: var(--text-muted);
+}
+
+/* Categories Section */
+.docs-categories {
+    padding: 80px 0;
+    background: var(--bg-primary);
+}
+
+.categories-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+}
+
+.category-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    padding: 32px;
+    background: var(--gradient-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    transition: var(--transition-normal);
+    cursor: pointer;
+}
+
+.category-card:hover {
+    border-color: var(--border-color-hover);
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-md);
+}
+
+.category-card.coming-soon {
+    opacity: 0.6;
+    cursor: default;
+}
+
+.category-card.coming-soon:hover {
+    transform: none;
+    box-shadow: none;
+}
+
+.category-icon {
+    width: 64px;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(74, 155, 217, 0.15);
+    border-radius: var(--radius-md);
+    margin-bottom: 20px;
+    color: var(--color-primary);
+}
+
+.category-content h3 {
+    font-size: 1.25rem;
+    margin-bottom: 8px;
+}
+
+.category-content p {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin-bottom: 16px;
+}
+
+.category-link {
+    color: var(--color-primary-light);
+    font-weight: 500;
+    font-size: 0.875rem;
+}
+
+.category-badge {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    padding: 4px 10px;
+    background: var(--color-primary);
+    color: var(--bg-primary);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-radius: var(--radius-full);
+}
+
+.category-badge.soon {
+    background: var(--bg-card);
+    color: var(--text-tertiary);
+    border: 1px solid var(--border-color);
+}
+
+/* Quick Links Section */
+.docs-quick-links {
+    padding: 60px 0 80px;
+    background: var(--bg-primary);
+    border-top: 1px solid var(--border-color);
+}
+
+.docs-quick-links h2 {
+    font-size: 1.5rem;
+    margin-bottom: 32px;
+    text-align: center;
+}
+
+.quick-links-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+}
+
+.quick-link {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 24px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    transition: var(--transition-fast);
+}
+
+.quick-link:hover {
+    border-color: var(--border-color-hover);
+    background: var(--bg-card-hover);
+}
+
+.quick-icon {
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(74, 155, 217, 0.15);
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+    flex-shrink: 0;
+}
+
+.quick-link h4 {
+    font-size: 1rem;
+    margin-bottom: 4px;
+}
+
+.quick-link p {
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    margin: 0;
+}
+
+/* Docs Content Layout */
+.docs-content {
+    padding: 60px 0 100px;
+    background: var(--bg-primary);
+}
+
+.docs-container {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    gap: 60px;
+    align-items: start;
+}
+
+/* Sidebar */
+.docs-sidebar {
+    position: relative;
+}
+
+.sidebar-sticky {
+    position: sticky;
+    top: 100px;
+}
+
+.docs-sidebar h4 {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-tertiary);
+    margin-bottom: 16px;
+}
+
+.docs-nav {
+    display: flex;
+    flex-direction: column;
+}
+
+.docs-nav a {
+    padding: 10px 16px;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    border-left: 2px solid var(--border-color);
+    transition: var(--transition-fast);
+}
+
+.docs-nav a:hover {
+    color: var(--text-primary);
+    border-color: var(--border-color-hover);
+}
+
+.docs-nav a.active {
+    color: var(--color-primary-light);
+    border-color: var(--color-primary);
+    background: rgba(74, 155, 217, 0.05);
+}
+
+/* Main Content */
+.docs-main {
+    max-width: 100%;
+    min-width: 0;
+}
+
+.docs-section {
+    margin-bottom: 64px;
+    scroll-margin-top: 100px;
+}
+
+.docs-section h2 {
+    font-size: 1.75rem;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.docs-section p {
+    color: var(--text-secondary);
+    line-height: 1.8;
+    margin-bottom: 24px;
+}
+
+/* Section Header Inline */
+.section-header-inline {
+    display: flex;
+    align-items: flex-start;
+    gap: 20px;
+    margin-bottom: 32px;
+}
+
+.section-header-inline h2 {
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 8px;
+}
+
+.section-subtitle {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    line-height: 1.6;
+    margin: 0;
+}
+
+/* Profile Badge */
+.profile-badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    font-size: 2rem;
+    background: var(--bg-card);
+    border-radius: var(--radius-md);
+    flex-shrink: 0;
+}
+
+.profile-badge.admin { background: rgba(74, 155, 217, 0.15); }
+.profile-badge.manager { background: rgba(245, 166, 35, 0.15); }
+.profile-badge.supervisor { background: rgba(52, 199, 89, 0.15); }
+.profile-badge.consultant { background: rgba(175, 82, 222, 0.15); }
+.profile-badge.technician { background: rgba(50, 173, 230, 0.15); }
+
+/* Profile Cards Grid */
+.profiles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.profile-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 24px 16px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    transition: var(--transition-normal);
+}
+
+.profile-card:hover {
+    border-color: var(--border-color-hover);
+    transform: translateY(-2px);
+}
+
+.profile-icon {
+    width: 56px;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-md);
+    margin-bottom: 12px;
+}
+
+.profile-emoji {
+    font-size: 2rem;
+}
+
+.profile-card h3 {
+    font-size: 1rem;
+    margin-bottom: 4px;
+}
+
+.profile-card p {
+    font-size: 0.8rem;
+    color: var(--text-tertiary);
+    margin-bottom: 12px;
+}
+
+.profile-tag {
+    display: inline-block;
+    padding: 4px 10px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-radius: var(--radius-full);
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+}
+
+/* Profile Card Colors */
+.profile-admin .profile-icon { background: rgba(74, 155, 217, 0.15); }
+.profile-admin .profile-tag { background: rgba(74, 155, 217, 0.2); color: var(--color-primary-light); }
+
+.profile-manager .profile-icon { background: rgba(245, 166, 35, 0.15); }
+.profile-manager .profile-tag { background: rgba(245, 166, 35, 0.2); color: var(--color-orange); }
+
+.profile-supervisor .profile-icon { background: rgba(52, 199, 89, 0.15); }
+.profile-supervisor .profile-tag { background: rgba(52, 199, 89, 0.2); color: var(--color-success); }
+
+.profile-consultant .profile-icon { background: rgba(175, 82, 222, 0.15); }
+.profile-consultant .profile-tag { background: rgba(175, 82, 222, 0.2); color: #AF52DE; }
+
+.profile-technician .profile-icon { background: rgba(50, 173, 230, 0.15); }
+.profile-technician .profile-tag { background: rgba(50, 173, 230, 0.2); color: #32ADE6; }
+
+/* Info Card */
+.info-card {
+    display: flex;
+    gap: 16px;
+    padding: 20px;
+    background: rgba(74, 155, 217, 0.1);
+    border: 1px solid rgba(74, 155, 217, 0.2);
+    border-radius: var(--radius-md);
+    margin-bottom: 24px;
+}
+
+.info-icon {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(74, 155, 217, 0.2);
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+    flex-shrink: 0;
+}
+
+.info-content h4 {
+    font-size: 1rem;
+    margin-bottom: 4px;
+    color: var(--color-primary-light);
+}
+
+.info-content p {
+    font-size: 0.9rem;
+    margin: 0;
+    color: var(--text-secondary);
+}
+
+/* Warning Card */
+.warning-card {
+    display: flex;
+    gap: 16px;
+    padding: 20px;
+    background: rgba(245, 166, 35, 0.1);
+    border: 1px solid rgba(245, 166, 35, 0.2);
+    border-radius: var(--radius-md);
+    margin-bottom: 24px;
+}
+
+.warning-icon {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(245, 166, 35, 0.2);
+    border-radius: var(--radius-sm);
+    color: var(--color-orange);
+    flex-shrink: 0;
+}
+
+.warning-content h4 {
+    font-size: 1rem;
+    margin-bottom: 4px;
+    color: var(--color-orange);
+}
+
+.warning-content p {
+    font-size: 0.9rem;
+    margin: 0;
+    color: var(--text-secondary);
+}
+
+/* Permissions Grid */
+.permissions-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+    margin-top: 24px;
+}
+
+.permission-category {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 24px;
+}
+
+.permission-category h4 {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 1rem;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border-color);
+    color: var(--text-primary);
+}
+
+.permission-category h4 svg {
+    color: var(--color-primary);
+}
+
+.permission-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.permission-list li {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 8px 0;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.permission-list li .icon {
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    font-weight: 700;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.permission-list li.allowed .icon {
+    background: rgba(52, 199, 89, 0.2);
+    color: var(--color-success);
+}
+
+.permission-list li.denied .icon {
+    background: rgba(255, 59, 48, 0.2);
+    color: var(--color-error);
+}
+
+.permission-list li.partial .icon {
+    background: rgba(245, 166, 35, 0.2);
+    color: var(--color-orange);
+}
+
+/* Tables */
+.table-wrapper {
+    margin-bottom: 32px;
+    overflow-x: auto;
+}
+
+.table-wrapper h4 {
+    font-size: 1.1rem;
+    margin-bottom: 16px;
+}
+
+.permissions-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.permissions-table th,
+.permissions-table td {
+    padding: 12px 16px;
+    text-align: center;
+    border: 1px solid var(--border-color);
+}
+
+.permissions-table th {
+    background: var(--bg-card);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.permissions-table th:first-child,
+.permissions-table td:first-child {
+    text-align: left;
+}
+
+.permissions-table td {
+    color: var(--text-secondary);
+}
+
+.permissions-table td.yes {
+    color: var(--color-success);
+    font-weight: 600;
+}
+
+.permissions-table td.no {
+    color: var(--color-error);
+    font-weight: 600;
+}
+
+.permissions-table td.partial {
+    color: var(--color-orange);
+    font-weight: 600;
+}
+
+.table-note {
+    font-size: 0.85rem;
+    color: var(--text-tertiary);
+    font-style: italic;
+    margin-top: 8px;
+}
+
+/* Status Flow */
+.status-flow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 16px;
+    padding: 32px;
+    background: var(--bg-card);
+    border-radius: var(--radius-md);
+    margin-bottom: 32px;
+}
+
+.status-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    background: var(--bg-tertiary);
+    border-radius: var(--radius-full);
+}
+
+.status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+.status-quote .status-dot { background: var(--color-primary); }
+.status-approved .status-dot { background: var(--color-success); }
+.status-progress .status-dot { background: var(--color-orange); }
+.status-done .status-dot { background: #32ADE6; }
+
+.status-name {
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
+.status-arrow {
+    color: var(--text-tertiary);
+    font-size: 1.25rem;
+}
+
+/* Status Details */
+.status-details {
+    display: grid;
+    gap: 24px;
+}
+
+.status-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 24px;
+}
+
+.status-card h4 {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 1.1rem;
+    margin-bottom: 16px;
+}
+
+.status-indicator {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+}
+
+.status-indicator.quote { background: var(--color-primary); }
+.status-indicator.approved { background: var(--color-success); }
+.status-indicator.done { background: #32ADE6; }
+
+.status-card p {
+    margin-bottom: 16px;
+}
+
+.status-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 16px;
+}
+
+.status-card ul li {
+    position: relative;
+    padding-left: 20px;
+    margin-bottom: 8px;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.status-card ul li::before {
+    content: '•';
+    position: absolute;
+    left: 0;
+    color: var(--text-tertiary);
+}
+
+.status-card .note {
+    font-size: 0.85rem;
+    color: var(--text-tertiary);
+    padding: 12px;
+    background: var(--bg-tertiary);
+    border-radius: var(--radius-sm);
+    margin: 0;
+}
+
+/* Status Permissions */
+.status-permissions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    margin-top: 16px;
+}
+
+.can-do,
+.cannot-do {
+    padding: 16px;
+    border-radius: var(--radius-sm);
+}
+
+.can-do {
+    background: rgba(52, 199, 89, 0.1);
+    border: 1px solid rgba(52, 199, 89, 0.2);
+}
+
+.cannot-do {
+    background: rgba(255, 59, 48, 0.1);
+    border: 1px solid rgba(255, 59, 48, 0.2);
+}
+
+.can-do h5,
+.cannot-do h5 {
+    font-size: 0.9rem;
+    margin-bottom: 12px;
+}
+
+.can-do h5 {
+    color: var(--color-success);
+}
+
+.cannot-do h5 {
+    color: var(--color-error);
+}
+
+.can-do ul li::before {
+    color: var(--color-success);
+}
+
+.cannot-do ul li::before {
+    color: var(--color-error);
+}
+
+/* FAQ Grid */
+.faq-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+}
+
+.faq-grid .faq-item {
+    margin-bottom: 0;
+}
+
+/* Docs Navigation */
+.docs-navigation {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    padding-top: 40px;
+    border-top: 1px solid var(--border-color);
+    margin-top: 40px;
+}
+
+.docs-navigation .nav-link {
+    display: flex;
+    flex-direction: column;
+    padding: 16px 24px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    transition: var(--transition-fast);
+    min-width: 200px;
+}
+
+.docs-navigation .nav-link:hover {
+    border-color: var(--border-color-hover);
+    background: var(--bg-card-hover);
+}
+
+.docs-navigation .nav-link.prev {
+    align-items: flex-start;
+}
+
+.docs-navigation .nav-link.next {
+    align-items: flex-end;
+    margin-left: auto;
+}
+
+.nav-direction {
+    font-size: 0.8rem;
+    color: var(--text-tertiary);
+    margin-bottom: 4px;
+}
+
+.nav-title {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .docs-container {
+        grid-template-columns: 1fr;
+    }
+
+    .docs-sidebar {
+        display: none;
+    }
+
+    .categories-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .permissions-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .faq-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .docs-hero {
+        padding: 120px 0 40px;
+    }
+
+    .docs-hero.compact {
+        padding: 100px 0 30px;
+    }
+
+    .categories-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .quick-links-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .section-header-inline {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .profile-badge {
+        width: 48px;
+        height: 48px;
+        font-size: 1.5rem;
+    }
+
+    .profiles-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .status-flow {
+        flex-direction: column;
+    }
+
+    .status-arrow {
+        transform: rotate(90deg);
+    }
+
+    .status-permissions {
+        grid-template-columns: 1fr;
+    }
+
+    .docs-navigation {
+        flex-direction: column;
+    }
+
+    .docs-navigation .nav-link {
+        min-width: 100%;
+    }
+
+    .docs-navigation .nav-link.next {
+        align-items: flex-start;
+    }
+
+    .permissions-table {
+        font-size: 0.8rem;
+    }
+
+    .permissions-table th,
+    .permissions-table td {
+        padding: 8px 10px;
+    }
+}
+
+@media (max-width: 480px) {
+    .profiles-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/firebase/hosting/public/docs/index-en.html
+++ b/firebase/hosting/public/docs/index-en.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Documentation - PráticOS</title>
+    <meta name="description" content="Complete PráticOS system documentation. Guides, tutorials and references to get the most out of the system.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/png" href="../assets/images/logo.png">
+    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="docs.css">
+</head>
+
+<body>
+    <nav class="navbar scrolled">
+        <div class="nav-container">
+            <a href="../index-en.html" class="nav-logo">
+                <img src="../assets/images/logo.png" alt="PráticOS" class="logo-img">
+                <span class="logo-text">Prát<span class="yellow">ic</span><span class="accent">OS</span></span>
+            </a>
+            <div class="nav-links">
+                <a href="../index-en.html">Home</a>
+                <a href="../index-en.html#features">Features</a>
+                <a href="index-en.html" class="active">Documentation</a>
+                <a href="../faq-en.html">FAQ</a>
+                <a href="../support-en.html">Support</a>
+            </div>
+            <div class="nav-actions">
+                <div class="lang-switch">
+                    <a href="index.html">PT</a>
+                    <a href="index-en.html" class="active">EN</a>
+                    <a href="index-es.html">ES</a>
+                </div>
+                <a href="../index-en.html#download" class="btn btn-primary">Download App</a>
+            </div>
+            <button class="nav-toggle" aria-label="Menu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+    </nav>
+
+    <section class="docs-hero">
+        <div class="hero-bg">
+            <div class="gradient-orb orb-1"></div>
+            <div class="gradient-orb orb-2"></div>
+        </div>
+        <div class="container">
+            <div class="docs-hero-content">
+                <div class="badge">Help Center</div>
+                <h1><span class="gradient-text">Documentation</span></h1>
+                <p class="hero-subtitle">Complete guides and references to get the most out of PráticOS. Find tutorials, tips and detailed information about each feature.</p>
+
+                <div class="docs-search">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="11" cy="11" r="8"></circle>
+                        <path d="M21 21l-4.35-4.35"></path>
+                    </svg>
+                    <input type="text" placeholder="Search documentation..." id="docs-search-input">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="docs-categories">
+        <div class="container">
+            <div class="categories-grid">
+                <a href="perfis-en.html" class="category-card">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                            <circle cx="9" cy="7" r="4"></circle>
+                            <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                            <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>User Profiles</h3>
+                        <p>Learn about the different profiles (Admin, Manager, Supervisor, Consultant, Technician) and their specific permissions.</p>
+                        <span class="category-link">View documentation &#8594;</span>
+                    </div>
+                    <div class="category-badge">New</div>
+                </a>
+
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                            <polyline points="14 2 14 8 20 8"></polyline>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Service Orders</h3>
+                        <p>How to create, edit and manage service orders. Status flow and best practices.</p>
+                        <span class="category-link">Coming soon</span>
+                    </div>
+                    <div class="category-badge soon">Coming soon</div>
+                </div>
+
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M9 11l3 3L22 4"></path>
+                            <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Forms & Checklists</h3>
+                        <p>Create custom checklists and forms to standardize your company's processes.</p>
+                        <span class="category-link">Coming soon</span>
+                    </div>
+                    <div class="category-badge soon">Coming soon</div>
+                </div>
+
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect>
+                            <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Customers & Devices</h3>
+                        <p>Manage your customer base and linked equipment/devices.</p>
+                        <span class="category-link">Coming soon</span>
+                    </div>
+                    <div class="category-badge soon">Coming soon</div>
+                </div>
+
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="12" y1="20" x2="12" y2="10"></line>
+                            <line x1="18" y1="20" x2="18" y2="4"></line>
+                            <line x1="6" y1="20" x2="6" y2="16"></line>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Financial Dashboard</h3>
+                        <p>Track revenue, received and pending amounts with charts and reports.</p>
+                        <span class="category-link">Coming soon</span>
+                    </div>
+                    <div class="category-badge soon">Coming soon</div>
+                </div>
+
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="3"></circle>
+                            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Settings</h3>
+                        <p>Customize the system: company data, collaborators, products, services and more.</p>
+                        <span class="category-link">Coming soon</span>
+                    </div>
+                    <div class="category-badge soon">Coming soon</div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="docs-quick-links">
+        <div class="container">
+            <h2>Quick Links</h2>
+            <div class="quick-links-grid">
+                <a href="../faq-en.html" class="quick-link">
+                    <div class="quick-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"></circle>
+                            <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
+                            <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                        </svg>
+                    </div>
+                    <div>
+                        <h4>FAQ</h4>
+                        <p>Answers to frequently asked questions</p>
+                    </div>
+                </a>
+
+                <a href="../support-en.html" class="quick-link">
+                    <div class="quick-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                        </svg>
+                    </div>
+                    <div>
+                        <h4>Support</h4>
+                        <p>Contact our team</p>
+                    </div>
+                </a>
+
+                <a href="../index-en.html#download" class="quick-link">
+                    <div class="quick-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                            <polyline points="7 10 12 15 17 10"></polyline>
+                            <line x1="12" y1="15" x2="12" y2="3"></line>
+                        </svg>
+                    </div>
+                    <div>
+                        <h4>Download App</h4>
+                        <p>Available for iOS and Android</p>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-brand">
+                    <a href="../index-en.html" class="nav-logo">
+                        <img src="../assets/images/logo.png" alt="PráticOS" class="logo-img">
+                        <span class="logo-text">Prát<span class="yellow">ic</span><span class="accent">OS</span></span>
+                    </a>
+                    <p>Complete service order management system. Simplify your business.</p>
+                </div>
+                <div class="footer-links">
+                    <h4>Product</h4>
+                    <a href="../index-en.html#features">Features</a>
+                    <a href="../index-en.html#pricing">Pricing</a>
+                    <a href="../index-en.html#download">Download</a>
+                </div>
+                <div class="footer-links">
+                    <h4>Documentation</h4>
+                    <a href="perfis-en.html">User Profiles</a>
+                    <a href="../faq-en.html">FAQ</a>
+                    <a href="../support-en.html">Support</a>
+                </div>
+                <div class="footer-links">
+                    <h4>Legal</h4>
+                    <a href="../privacy-en.html">Privacy</a>
+                    <a href="../terms-en.html">Terms of Use</a>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2025 PráticOS. All rights reserved.</p>
+                <p>Developed by <a href="https://www.rafsoft.com.br" target="_blank" rel="noopener">Rafsoft</a></p>
+            </div>
+        </div>
+    </footer>
+
+    <div class="mobile-menu">
+        <div class="mobile-menu-content">
+            <a href="../index-en.html">Home</a>
+            <a href="../index-en.html#features">Features</a>
+            <a href="index-en.html">Documentation</a>
+            <a href="../faq-en.html">FAQ</a>
+            <a href="../support-en.html">Support</a>
+            <div class="mobile-lang">
+                <a href="index.html">PT</a>
+                <a href="index-en.html" class="active">EN</a>
+                <a href="index-es.html">ES</a>
+            </div>
+            <a href="../index-en.html#download" class="btn btn-primary">Download App</a>
+        </div>
+    </div>
+
+    <script>
+        const navToggle = document.querySelector('.nav-toggle');
+        const mobileMenu = document.querySelector('.mobile-menu');
+        const body = document.body;
+
+        navToggle.addEventListener('click', () => {
+            navToggle.classList.toggle('active');
+            mobileMenu.classList.toggle('active');
+            body.classList.toggle('menu-open');
+        });
+
+        mobileMenu.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', () => {
+                navToggle.classList.remove('active');
+                mobileMenu.classList.remove('active');
+                body.classList.remove('menu-open');
+            });
+        });
+
+        const searchInput = document.getElementById('docs-search-input');
+        const cards = document.querySelectorAll('.category-card');
+
+        searchInput.addEventListener('input', (e) => {
+            const query = e.target.value.toLowerCase();
+            cards.forEach(card => {
+                const text = card.textContent.toLowerCase();
+                card.style.display = text.includes(query) || query === '' ? '' : 'none';
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/firebase/hosting/public/docs/index-es.html
+++ b/firebase/hosting/public/docs/index-es.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Documentación - PráticOS</title>
+    <meta name="description" content="Documentación completa del sistema PráticOS. Guías, tutoriales y referencias para aprovechar al máximo el sistema.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/png" href="../assets/images/logo.png">
+    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="docs.css">
+</head>
+
+<body>
+    <nav class="navbar scrolled">
+        <div class="nav-container">
+            <a href="../index-es.html" class="nav-logo">
+                <img src="../assets/images/logo.png" alt="PráticOS" class="logo-img">
+                <span class="logo-text">Prát<span class="yellow">ic</span><span class="accent">OS</span></span>
+            </a>
+            <div class="nav-links">
+                <a href="../index-es.html">Inicio</a>
+                <a href="../index-es.html#features">Funcionalidades</a>
+                <a href="index-es.html" class="active">Documentación</a>
+                <a href="../faq-es.html">FAQ</a>
+                <a href="../support-es.html">Soporte</a>
+            </div>
+            <div class="nav-actions">
+                <div class="lang-switch">
+                    <a href="index.html">PT</a>
+                    <a href="index-en.html">EN</a>
+                    <a href="index-es.html" class="active">ES</a>
+                </div>
+                <a href="../index-es.html#download" class="btn btn-primary">Descargar App</a>
+            </div>
+            <button class="nav-toggle" aria-label="Menu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+    </nav>
+
+    <section class="docs-hero">
+        <div class="hero-bg">
+            <div class="gradient-orb orb-1"></div>
+            <div class="gradient-orb orb-2"></div>
+        </div>
+        <div class="container">
+            <div class="docs-hero-content">
+                <div class="badge">Centro de Ayuda</div>
+                <h1><span class="gradient-text">Documentación</span></h1>
+                <p class="hero-subtitle">Guías completas y referencias para aprovechar al máximo PráticOS. Encuentra tutoriales, consejos e información detallada sobre cada funcionalidad.</p>
+
+                <div class="docs-search">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="11" cy="11" r="8"></circle>
+                        <path d="M21 21l-4.35-4.35"></path>
+                    </svg>
+                    <input type="text" placeholder="Buscar en la documentación..." id="docs-search-input">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="docs-categories">
+        <div class="container">
+            <div class="categories-grid">
+                <a href="perfis-es.html" class="category-card">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                            <circle cx="9" cy="7" r="4"></circle>
+                            <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                            <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Perfiles de Usuarios</h3>
+                        <p>Conoce los diferentes perfiles (Admin, Gerente, Supervisor, Consultor, Técnico) y sus permisos específicos.</p>
+                        <span class="category-link">Ver documentación &#8594;</span>
+                    </div>
+                    <div class="category-badge">Nuevo</div>
+                </a>
+
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                            <polyline points="14 2 14 8 20 8"></polyline>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Órdenes de Servicio</h3>
+                        <p>Cómo crear, editar y gestionar órdenes de servicio. Flujo de estados y mejores prácticas.</p>
+                        <span class="category-link">Próximamente</span>
+                    </div>
+                    <div class="category-badge soon">Próximamente</div>
+                </div>
+
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M9 11l3 3L22 4"></path>
+                            <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Formularios y Checklists</h3>
+                        <p>Crea checklists y formularios personalizados para estandarizar los procesos de tu empresa.</p>
+                        <span class="category-link">Próximamente</span>
+                    </div>
+                    <div class="category-badge soon">Próximamente</div>
+                </div>
+
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect>
+                            <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Clientes y Dispositivos</h3>
+                        <p>Gestiona tu base de clientes y equipos/dispositivos vinculados.</p>
+                        <span class="category-link">Próximamente</span>
+                    </div>
+                    <div class="category-badge soon">Próximamente</div>
+                </div>
+
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="12" y1="20" x2="12" y2="10"></line>
+                            <line x1="18" y1="20" x2="18" y2="4"></line>
+                            <line x1="6" y1="20" x2="6" y2="16"></line>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Dashboard Financiero</h3>
+                        <p>Acompaña facturación, valores recibidos y pendientes con gráficos e informes.</p>
+                        <span class="category-link">Próximamente</span>
+                    </div>
+                    <div class="category-badge soon">Próximamente</div>
+                </div>
+
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="3"></circle>
+                            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Configuraciones</h3>
+                        <p>Personaliza el sistema: datos de la empresa, colaboradores, productos, servicios y más.</p>
+                        <span class="category-link">Próximamente</span>
+                    </div>
+                    <div class="category-badge soon">Próximamente</div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="docs-quick-links">
+        <div class="container">
+            <h2>Enlaces Rápidos</h2>
+            <div class="quick-links-grid">
+                <a href="../faq-es.html" class="quick-link">
+                    <div class="quick-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"></circle>
+                            <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
+                            <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                        </svg>
+                    </div>
+                    <div>
+                        <h4>Preguntas Frecuentes</h4>
+                        <p>Respuestas a las dudas más comunes</p>
+                    </div>
+                </a>
+
+                <a href="../support-es.html" class="quick-link">
+                    <div class="quick-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                        </svg>
+                    </div>
+                    <div>
+                        <h4>Soporte</h4>
+                        <p>Contacta con nuestro equipo</p>
+                    </div>
+                </a>
+
+                <a href="../index-es.html#download" class="quick-link">
+                    <div class="quick-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                            <polyline points="7 10 12 15 17 10"></polyline>
+                            <line x1="12" y1="15" x2="12" y2="3"></line>
+                        </svg>
+                    </div>
+                    <div>
+                        <h4>Descargar App</h4>
+                        <p>Disponible para iOS y Android</p>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-brand">
+                    <a href="../index-es.html" class="nav-logo">
+                        <img src="../assets/images/logo.png" alt="PráticOS" class="logo-img">
+                        <span class="logo-text">Prát<span class="yellow">ic</span><span class="accent">OS</span></span>
+                    </a>
+                    <p>Sistema completo para gestión de órdenes de servicio. Simplifica tu negocio.</p>
+                </div>
+                <div class="footer-links">
+                    <h4>Producto</h4>
+                    <a href="../index-es.html#features">Funcionalidades</a>
+                    <a href="../index-es.html#pricing">Planes</a>
+                    <a href="../index-es.html#download">Descarga</a>
+                </div>
+                <div class="footer-links">
+                    <h4>Documentación</h4>
+                    <a href="perfis-es.html">Perfiles de Usuarios</a>
+                    <a href="../faq-es.html">FAQ</a>
+                    <a href="../support-es.html">Soporte</a>
+                </div>
+                <div class="footer-links">
+                    <h4>Legal</h4>
+                    <a href="../privacy-es.html">Privacidad</a>
+                    <a href="../terms-es.html">Términos de Uso</a>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2025 PráticOS. Todos los derechos reservados.</p>
+                <p>Desarrollado por <a href="https://www.rafsoft.com.br" target="_blank" rel="noopener">Rafsoft</a></p>
+            </div>
+        </div>
+    </footer>
+
+    <div class="mobile-menu">
+        <div class="mobile-menu-content">
+            <a href="../index-es.html">Inicio</a>
+            <a href="../index-es.html#features">Funcionalidades</a>
+            <a href="index-es.html">Documentación</a>
+            <a href="../faq-es.html">FAQ</a>
+            <a href="../support-es.html">Soporte</a>
+            <div class="mobile-lang">
+                <a href="index.html">PT</a>
+                <a href="index-en.html">EN</a>
+                <a href="index-es.html" class="active">ES</a>
+            </div>
+            <a href="../index-es.html#download" class="btn btn-primary">Descargar App</a>
+        </div>
+    </div>
+
+    <script>
+        const navToggle = document.querySelector('.nav-toggle');
+        const mobileMenu = document.querySelector('.mobile-menu');
+        const body = document.body;
+
+        navToggle.addEventListener('click', () => {
+            navToggle.classList.toggle('active');
+            mobileMenu.classList.toggle('active');
+            body.classList.toggle('menu-open');
+        });
+
+        mobileMenu.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', () => {
+                navToggle.classList.remove('active');
+                mobileMenu.classList.remove('active');
+                body.classList.remove('menu-open');
+            });
+        });
+
+        const searchInput = document.getElementById('docs-search-input');
+        const cards = document.querySelectorAll('.category-card');
+
+        searchInput.addEventListener('input', (e) => {
+            const query = e.target.value.toLowerCase();
+            cards.forEach(card => {
+                const text = card.textContent.toLowerCase();
+                card.style.display = text.includes(query) || query === '' ? '' : 'none';
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/firebase/hosting/public/docs/index.html
+++ b/firebase/hosting/public/docs/index.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Documentação - PráticOS</title>
+    <meta name="description" content="Documentação completa do sistema PráticOS. Guias, tutoriais e referências para aproveitar ao máximo o sistema.">
+    <meta name="keywords" content="praticos, documentação, manual, guia, tutorial">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Documentação - PráticOS">
+    <meta property="og:description" content="Documentação completa do sistema PráticOS.">
+    <meta property="og:image" content="../assets/images/logo.png">
+    <meta property="og:type" content="website">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="../assets/images/logo.png">
+
+    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="docs.css">
+</head>
+
+<body>
+    <!-- Navigation -->
+    <nav class="navbar scrolled">
+        <div class="nav-container">
+            <a href="../index.html" class="nav-logo">
+                <img src="../assets/images/logo.png" alt="PráticOS" class="logo-img">
+                <span class="logo-text">Prát<span class="yellow">ic</span><span class="accent">OS</span></span>
+            </a>
+            <div class="nav-links">
+                <a href="../index.html">Início</a>
+                <a href="../index.html#features">Funcionalidades</a>
+                <a href="index.html" class="active">Documentação</a>
+                <a href="../faq.html">FAQ</a>
+                <a href="../support.html">Suporte</a>
+            </div>
+            <div class="nav-actions">
+                <div class="lang-switch">
+                    <a href="index.html" class="active">PT</a>
+                    <a href="index-en.html">EN</a>
+                    <a href="index-es.html">ES</a>
+                </div>
+                <a href="../index.html#download" class="btn btn-primary">Baixar App</a>
+            </div>
+            <button class="nav-toggle" aria-label="Menu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+    </nav>
+
+    <!-- Page Header -->
+    <section class="docs-hero">
+        <div class="hero-bg">
+            <div class="gradient-orb orb-1"></div>
+            <div class="gradient-orb orb-2"></div>
+        </div>
+        <div class="container">
+            <div class="docs-hero-content">
+                <div class="badge">Central de Ajuda</div>
+                <h1><span class="gradient-text">Documentação</span></h1>
+                <p class="hero-subtitle">Guias completos e referências para aproveitar ao máximo o PráticOS. Encontre tutoriais, dicas e informações detalhadas sobre cada funcionalidade.</p>
+
+                <div class="docs-search">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="11" cy="11" r="8"></circle>
+                        <path d="M21 21l-4.35-4.35"></path>
+                    </svg>
+                    <input type="text" placeholder="Buscar na documentação..." id="docs-search-input">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Docs Categories -->
+    <section class="docs-categories">
+        <div class="container">
+            <div class="categories-grid">
+                <!-- Perfis de Usuários -->
+                <a href="perfis.html" class="category-card">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                            <circle cx="9" cy="7" r="4"></circle>
+                            <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                            <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Perfis de Usuários</h3>
+                        <p>Conheça os diferentes perfis (Admin, Gerente, Supervisor, Consultor, Técnico) e suas permissões específicas.</p>
+                        <span class="category-link">Ver documentação &#8594;</span>
+                    </div>
+                    <div class="category-badge">Novo</div>
+                </a>
+
+                <!-- Ordens de Serviço (Em breve) -->
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                            <polyline points="14 2 14 8 20 8"></polyline>
+                            <line x1="16" y1="13" x2="8" y2="13"></line>
+                            <line x1="16" y1="17" x2="8" y2="17"></line>
+                            <polyline points="10 9 9 9 8 9"></polyline>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Ordens de Serviço</h3>
+                        <p>Como criar, editar e gerenciar ordens de serviço. Fluxo de status e boas práticas.</p>
+                        <span class="category-link">Em breve</span>
+                    </div>
+                    <div class="category-badge soon">Em breve</div>
+                </div>
+
+                <!-- Formulários Dinâmicos (Em breve) -->
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M9 11l3 3L22 4"></path>
+                            <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Formulários e Checklists</h3>
+                        <p>Crie checklists e formulários personalizados para padronizar processos da sua empresa.</p>
+                        <span class="category-link">Em breve</span>
+                    </div>
+                    <div class="category-badge soon">Em breve</div>
+                </div>
+
+                <!-- Clientes e Dispositivos (Em breve) -->
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect>
+                            <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Clientes e Dispositivos</h3>
+                        <p>Gerencie sua base de clientes e equipamentos/dispositivos vinculados.</p>
+                        <span class="category-link">Em breve</span>
+                    </div>
+                    <div class="category-badge soon">Em breve</div>
+                </div>
+
+                <!-- Dashboard Financeiro (Em breve) -->
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="12" y1="20" x2="12" y2="10"></line>
+                            <line x1="18" y1="20" x2="18" y2="4"></line>
+                            <line x1="6" y1="20" x2="6" y2="16"></line>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Dashboard Financeiro</h3>
+                        <p>Acompanhe faturamento, valores recebidos e a receber com gráficos e relatórios.</p>
+                        <span class="category-link">Em breve</span>
+                    </div>
+                    <div class="category-badge soon">Em breve</div>
+                </div>
+
+                <!-- Configurações (Em breve) -->
+                <div class="category-card coming-soon">
+                    <div class="category-icon">
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="3"></circle>
+                            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                        </svg>
+                    </div>
+                    <div class="category-content">
+                        <h3>Configurações</h3>
+                        <p>Personalize o sistema: dados da empresa, colaboradores, produtos, serviços e mais.</p>
+                        <span class="category-link">Em breve</span>
+                    </div>
+                    <div class="category-badge soon">Em breve</div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Quick Links -->
+    <section class="docs-quick-links">
+        <div class="container">
+            <h2>Links Rápidos</h2>
+            <div class="quick-links-grid">
+                <a href="../faq.html" class="quick-link">
+                    <div class="quick-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"></circle>
+                            <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
+                            <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                        </svg>
+                    </div>
+                    <div>
+                        <h4>Perguntas Frequentes</h4>
+                        <p>Respostas para as dúvidas mais comuns</p>
+                    </div>
+                </a>
+
+                <a href="../support.html" class="quick-link">
+                    <div class="quick-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                        </svg>
+                    </div>
+                    <div>
+                        <h4>Suporte</h4>
+                        <p>Entre em contato com nossa equipe</p>
+                    </div>
+                </a>
+
+                <a href="../index.html#download" class="quick-link">
+                    <div class="quick-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                            <polyline points="7 10 12 15 17 10"></polyline>
+                            <line x1="12" y1="15" x2="12" y2="3"></line>
+                        </svg>
+                    </div>
+                    <div>
+                        <h4>Baixar App</h4>
+                        <p>Disponível para iOS e Android</p>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-brand">
+                    <a href="../index.html" class="nav-logo">
+                        <img src="../assets/images/logo.png" alt="PráticOS" class="logo-img">
+                        <span class="logo-text">Prát<span class="yellow">ic</span><span class="accent">OS</span></span>
+                    </a>
+                    <p>Sistema completo para gestão de ordens de serviço. Simplifique seu negócio.</p>
+                </div>
+                <div class="footer-links">
+                    <h4>Produto</h4>
+                    <a href="../index.html#features">Funcionalidades</a>
+                    <a href="../index.html#pricing">Planos</a>
+                    <a href="../index.html#download">Download</a>
+                </div>
+                <div class="footer-links">
+                    <h4>Documentação</h4>
+                    <a href="perfis.html">Perfis de Usuários</a>
+                    <a href="../faq.html">FAQ</a>
+                    <a href="../support.html">Suporte</a>
+                </div>
+                <div class="footer-links">
+                    <h4>Legal</h4>
+                    <a href="../privacy.html">Privacidade</a>
+                    <a href="../terms.html">Termos de Uso</a>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2025 PráticOS. Todos os direitos reservados.</p>
+                <p>Desenvolvido por <a href="https://www.rafsoft.com.br" target="_blank" rel="noopener">Rafsoft</a></p>
+            </div>
+        </div>
+    </footer>
+
+    <!-- Mobile Menu -->
+    <div class="mobile-menu">
+        <div class="mobile-menu-content">
+            <a href="../index.html">Início</a>
+            <a href="../index.html#features">Funcionalidades</a>
+            <a href="index.html">Documentação</a>
+            <a href="../faq.html">FAQ</a>
+            <a href="../support.html">Suporte</a>
+            <div class="mobile-lang">
+                <a href="index.html" class="active">PT</a>
+                <a href="index-en.html">EN</a>
+                <a href="index-es.html">ES</a>
+            </div>
+            <a href="../index.html#download" class="btn btn-primary">Baixar App</a>
+        </div>
+    </div>
+
+    <script>
+        // Mobile menu toggle
+        const navToggle = document.querySelector('.nav-toggle');
+        const mobileMenu = document.querySelector('.mobile-menu');
+        const body = document.body;
+
+        navToggle.addEventListener('click', () => {
+            navToggle.classList.toggle('active');
+            mobileMenu.classList.toggle('active');
+            body.classList.toggle('menu-open');
+        });
+
+        // Close mobile menu on link click
+        mobileMenu.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', () => {
+                navToggle.classList.remove('active');
+                mobileMenu.classList.remove('active');
+                body.classList.remove('menu-open');
+            });
+        });
+
+        // Simple search filter (can be enhanced)
+        const searchInput = document.getElementById('docs-search-input');
+        const cards = document.querySelectorAll('.category-card');
+
+        searchInput.addEventListener('input', (e) => {
+            const query = e.target.value.toLowerCase();
+            cards.forEach(card => {
+                const text = card.textContent.toLowerCase();
+                if (text.includes(query) || query === '') {
+                    card.style.display = '';
+                } else {
+                    card.style.display = 'none';
+                }
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/firebase/hosting/public/docs/perfis-en.html
+++ b/firebase/hosting/public/docs/perfis-en.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>User Profiles - PráticOS Documentation</title>
+    <meta name="description" content="Complete documentation about user profiles and permissions in the PráticOS system.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/png" href="../assets/images/logo.png">
+    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+    <nav class="navbar scrolled">
+        <div class="nav-container">
+            <a href="../index-en.html" class="nav-logo">
+                <img src="../assets/images/logo.png" alt="PráticOS" class="logo-img">
+                <span class="logo-text">Prát<span class="yellow">ic</span><span class="accent">OS</span></span>
+            </a>
+            <div class="nav-links">
+                <a href="../index-en.html">Home</a>
+                <a href="../index-en.html#features">Features</a>
+                <a href="index-en.html" class="active">Documentation</a>
+                <a href="../faq-en.html">FAQ</a>
+                <a href="../support-en.html">Support</a>
+            </div>
+            <div class="nav-actions">
+                <div class="lang-switch">
+                    <a href="perfis.html">PT</a>
+                    <a href="perfis-en.html" class="active">EN</a>
+                    <a href="perfis-es.html">ES</a>
+                </div>
+                <a href="../index-en.html#download" class="btn btn-primary">Download App</a>
+            </div>
+            <button class="nav-toggle" aria-label="Menu"><span></span><span></span><span></span></button>
+        </div>
+    </nav>
+
+    <section class="docs-hero compact">
+        <div class="hero-bg"><div class="gradient-orb orb-1"></div><div class="gradient-orb orb-2"></div></div>
+        <div class="container">
+            <div class="docs-breadcrumb">
+                <a href="index-en.html">Documentation</a><span>/</span><span>User Profiles</span>
+            </div>
+            <div class="docs-hero-content">
+                <h1>User <span class="gradient-text">Profiles</span></h1>
+                <p class="hero-subtitle">Learn about the different profiles available in PráticOS and their specific permissions for each role in your company.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="docs-content">
+        <div class="container docs-container">
+            <aside class="docs-sidebar">
+                <div class="sidebar-sticky">
+                    <h4>On this page</h4>
+                    <nav class="docs-nav">
+                        <a href="#overview" class="active">Overview</a>
+                        <a href="#profiles">Available Profiles</a>
+                        <a href="#admin">Administrator</a>
+                        <a href="#manager">Manager</a>
+                        <a href="#supervisor">Supervisor</a>
+                        <a href="#consultant">Consultant</a>
+                        <a href="#technician">Technician</a>
+                        <a href="#matrix">Permission Matrix</a>
+                    </nav>
+                </div>
+            </aside>
+
+            <main class="docs-main">
+                <section id="overview" class="docs-section">
+                    <h2>RBAC System Overview</h2>
+                    <p>PráticOS uses a role-based access control system (<strong>RBAC - Role-Based Access Control</strong>) to manage permissions for each company's collaborators.</p>
+                    <div class="info-card">
+                        <div class="info-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg></div>
+                        <div class="info-content">
+                            <h4>Multi-Tenancy</h4>
+                            <p>A user can have different profiles in different companies. For example, be an Administrator in one company and a Technician in another.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="profiles" class="docs-section">
+                    <h2>Available Profiles</h2>
+                    <p>The system has 5 distinct profiles, each designed to serve different roles within the organization:</p>
+                    <div class="profiles-grid">
+                        <a href="#admin" class="profile-card profile-admin">
+                            <div class="profile-icon"><span class="profile-emoji">&#128104;&#8205;&#128188;</span></div>
+                            <h3>Administrator</h3>
+                            <p>Full system access</p>
+                            <span class="profile-tag">Complete Management</span>
+                        </a>
+                        <a href="#manager" class="profile-card profile-manager">
+                            <div class="profile-icon"><span class="profile-emoji">&#128176;</span></div>
+                            <h3>Manager</h3>
+                            <p>Financial management and reports</p>
+                            <span class="profile-tag">Financial</span>
+                        </a>
+                        <a href="#supervisor" class="profile-card profile-supervisor">
+                            <div class="profile-icon"><span class="profile-emoji">&#129489;&#8205;&#128295;</span></div>
+                            <h3>Supervisor</h3>
+                            <p>Operational management of technicians</p>
+                            <span class="profile-tag">Operational</span>
+                        </a>
+                        <a href="#consultant" class="profile-card profile-consultant">
+                            <div class="profile-icon"><span class="profile-emoji">&#129489;&#8205;&#128188;</span></div>
+                            <h3>Consultant</h3>
+                            <p>Sales and commercial tracking</p>
+                            <span class="profile-tag">Commercial</span>
+                        </a>
+                        <a href="#technician" class="profile-card profile-technician">
+                            <div class="profile-icon"><span class="profile-emoji">&#128119;</span></div>
+                            <h3>Technician</h3>
+                            <p>Field service execution</p>
+                            <span class="profile-tag">Execution</span>
+                        </a>
+                    </div>
+                </section>
+
+                <section id="admin" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge admin">&#128104;&#8205;&#128188;</span>
+                        <div><h2>Administrator</h2><p class="section-subtitle">Full system access. Responsible for company settings and managing all resources.</p></div>
+                    </div>
+                    <div class="permissions-grid">
+                        <div class="permission-category">
+                            <h4><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg> Service Orders</h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> View all company SOs</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Create new SOs</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Edit any SO</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Assign/reassign technicians</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Execute services</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Delete SOs</li>
+                            </ul>
+                        </div>
+                        <div class="permission-category">
+                            <h4><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"></line><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path></svg> Financial Data</h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> View values and prices</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> View billing</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Access financial reports</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Edit values and prices</li>
+                            </ul>
+                        </div>
+                        <div class="permission-category">
+                            <h4><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle></svg> Registrations</h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Manage customers</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Manage products</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Manage services</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Manage devices</li>
+                            </ul>
+                        </div>
+                        <div class="permission-category">
+                            <h4><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg> Administration</h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Manage users and collaborators</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Manage profiles and permissions</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Configure company data</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Configure global parameters</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="manager" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge manager">&#128176;</span>
+                        <div><h2>Manager (Financial)</h2><p class="section-subtitle">Responsible for the company's financial management. Full access to financial data and reports, but without interfering with technical operations.</p></div>
+                    </div>
+                    <div class="permissions-grid">
+                        <div class="permission-category">
+                            <h4><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg> Service Orders</h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> View all SOs</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Create new SOs</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Edit SOs (fiscal/financial adjustments)</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Assign technicians</li>
+                                <li class="partial"><span class="icon">&#9888;</span> Delete SOs (only 'Quote' status)</li>
+                            </ul>
+                        </div>
+                        <div class="permission-category">
+                            <h4><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"></line><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path></svg> Financial Data</h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> View values and prices</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> View billing</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Access financial reports</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Edit values and prices</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="supervisor" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge supervisor">&#129489;&#8205;&#128295;</span>
+                        <div><h2>Supervisor</h2><p class="section-subtitle">Responsible for operational management of the technical team. Coordinates work distribution and monitors service execution.</p></div>
+                    </div>
+                    <div class="warning-card">
+                        <div class="warning-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg></div>
+                        <div class="warning-content"><h4>No Financial Access</h4><p>This profile does not view values, prices, billing or financial reports. Ideal for collaborators focused on operations.</p></div>
+                    </div>
+                    <div class="permissions-grid">
+                        <div class="permission-category">
+                            <h4><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg> Service Orders</h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> View all SOs (no values)</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Create new SOs</li>
+                                <li class="partial"><span class="icon">&#9888;</span> Full edit (only 'Quote' status)</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Assign/reassign technicians</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Execute services</li>
+                            </ul>
+                        </div>
+                        <div class="permission-category">
+                            <h4><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"></line><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path></svg> Financial Data</h4>
+                            <ul class="permission-list">
+                                <li class="denied"><span class="icon">&#10007;</span> View values and prices</li>
+                                <li class="denied"><span class="icon">&#10007;</span> View billing</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Access financial reports</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Generate SO PDF</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="consultant" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge consultant">&#129489;&#8205;&#128188;</span>
+                        <div><h2>Consultant (Salesperson)</h2><p class="section-subtitle">Commercial profile focused on sales and quote creation. Limited access to their own SOs and customer data.</p></div>
+                    </div>
+                    <div class="info-card">
+                        <div class="info-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg></div>
+                        <div class="info-content"><h4>Limited Visibility</h4><p>Consultants only see SOs they created. In case of vacation or absence, the Administrator can reassign SOs to another consultant.</p></div>
+                    </div>
+                </section>
+
+                <section id="technician" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge technician">&#128119;</span>
+                        <div><h2>Technician</h2><p class="section-subtitle">Responsible for field service execution. Access to company Service Orders for execution and reporting.</p></div>
+                    </div>
+                    <div class="warning-card">
+                        <div class="warning-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg></div>
+                        <div class="warning-content"><h4>Operational Profile</h4><p>Focused on execution. Does not view financial values and has limited editing on SOs after approval.</p></div>
+                    </div>
+                </section>
+
+                <section id="matrix" class="docs-section">
+                    <h2>Permission Matrix</h2>
+                    <p>Consolidated view of all permissions by profile:</p>
+                    <div class="table-wrapper">
+                        <h4>Service Orders</h4>
+                        <table class="permissions-table">
+                            <thead><tr><th>Permission</th><th>Admin</th><th>Manager</th><th>Supervisor</th><th>Consultant</th><th>Technician</th></tr></thead>
+                            <tbody>
+                                <tr><td>View all SOs</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td></tr>
+                                <tr><td>Create SOs</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td></tr>
+                                <tr><td>Assign technicians</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="no">&#10007;</td></tr>
+                                <tr><td>Execute SOs</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="table-wrapper">
+                        <h4>Financial Data</h4>
+                        <table class="permissions-table">
+                            <thead><tr><th>Permission</th><th>Admin</th><th>Manager</th><th>Supervisor</th><th>Consultant</th><th>Technician</th></tr></thead>
+                            <tbody>
+                                <tr><td>View prices</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td></tr>
+                                <tr><td>View billing</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="no">&#10007;</td><td class="no">&#10007;</td></tr>
+                                <tr><td>Financial reports</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="no">&#10007;</td><td class="no">&#10007;</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <div class="docs-navigation">
+                    <a href="index-en.html" class="nav-link prev"><span class="nav-direction">&#8592; Back</span><span class="nav-title">Documentation</span></a>
+                    <a href="../support-en.html" class="nav-link next"><span class="nav-direction">Next &#8594;</span><span class="nav-title">Support</span></a>
+                </div>
+            </main>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-bottom">
+                <p>&copy; 2025 PráticOS. All rights reserved.</p>
+                <p>Developed by <a href="https://www.rafsoft.com.br" target="_blank" rel="noopener">Rafsoft</a></p>
+            </div>
+        </div>
+    </footer>
+
+    <div class="mobile-menu">
+        <div class="mobile-menu-content">
+            <a href="../index-en.html">Home</a>
+            <a href="index-en.html">Documentation</a>
+            <a href="../faq-en.html">FAQ</a>
+            <a href="../support-en.html">Support</a>
+            <div class="mobile-lang"><a href="perfis.html">PT</a><a href="perfis-en.html" class="active">EN</a><a href="perfis-es.html">ES</a></div>
+            <a href="../index-en.html#download" class="btn btn-primary">Download App</a>
+        </div>
+    </div>
+
+    <script>
+        const navToggle = document.querySelector('.nav-toggle');
+        const mobileMenu = document.querySelector('.mobile-menu');
+        const body = document.body;
+        navToggle.addEventListener('click', () => { navToggle.classList.toggle('active'); mobileMenu.classList.toggle('active'); body.classList.toggle('menu-open'); });
+        mobileMenu.querySelectorAll('a').forEach(link => { link.addEventListener('click', () => { navToggle.classList.remove('active'); mobileMenu.classList.remove('active'); body.classList.remove('menu-open'); }); });
+
+        const sections = document.querySelectorAll('.docs-section');
+        const navLinks = document.querySelectorAll('.docs-nav a');
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    navLinks.forEach(link => link.classList.remove('active'));
+                    const activeLink = document.querySelector(`.docs-nav a[href="#${entry.target.id}"]`);
+                    if (activeLink) activeLink.classList.add('active');
+                }
+            });
+        }, { rootMargin: '-100px 0px -70% 0px', threshold: 0 });
+        sections.forEach(section => observer.observe(section));
+
+        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+            anchor.addEventListener('click', function(e) {
+                e.preventDefault();
+                const target = document.querySelector(this.getAttribute('href'));
+                if (target) { window.scrollTo({ top: target.getBoundingClientRect().top + window.pageYOffset - 100, behavior: 'smooth' }); }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/firebase/hosting/public/docs/perfis-es.html
+++ b/firebase/hosting/public/docs/perfis-es.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Perfiles de Usuarios - PráticOS Documentación</title>
+    <meta name="description" content="Documentación completa sobre los perfiles de usuarios y permisos del sistema PráticOS.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/png" href="../assets/images/logo.png">
+    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+    <nav class="navbar scrolled">
+        <div class="nav-container">
+            <a href="../index-es.html" class="nav-logo">
+                <img src="../assets/images/logo.png" alt="PráticOS" class="logo-img">
+                <span class="logo-text">Prát<span class="yellow">ic</span><span class="accent">OS</span></span>
+            </a>
+            <div class="nav-links">
+                <a href="../index-es.html">Inicio</a>
+                <a href="../index-es.html#features">Funcionalidades</a>
+                <a href="index-es.html" class="active">Documentación</a>
+                <a href="../faq-es.html">FAQ</a>
+                <a href="../support-es.html">Soporte</a>
+            </div>
+            <div class="nav-actions">
+                <div class="lang-switch">
+                    <a href="perfis.html">PT</a>
+                    <a href="perfis-en.html">EN</a>
+                    <a href="perfis-es.html" class="active">ES</a>
+                </div>
+                <a href="../index-es.html#download" class="btn btn-primary">Descargar App</a>
+            </div>
+            <button class="nav-toggle" aria-label="Menu"><span></span><span></span><span></span></button>
+        </div>
+    </nav>
+
+    <section class="docs-hero compact">
+        <div class="hero-bg"><div class="gradient-orb orb-1"></div><div class="gradient-orb orb-2"></div></div>
+        <div class="container">
+            <div class="docs-breadcrumb">
+                <a href="index-es.html">Documentación</a><span>/</span><span>Perfiles de Usuarios</span>
+            </div>
+            <div class="docs-hero-content">
+                <h1>Perfiles de <span class="gradient-text">Usuarios</span></h1>
+                <p class="hero-subtitle">Conoce los diferentes perfiles disponibles en PráticOS y sus permisos específicos para cada función en tu empresa.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="docs-content">
+        <div class="container docs-container">
+            <aside class="docs-sidebar">
+                <div class="sidebar-sticky">
+                    <h4>En esta página</h4>
+                    <nav class="docs-nav">
+                        <a href="#overview" class="active">Visión General</a>
+                        <a href="#profiles">Perfiles Disponibles</a>
+                        <a href="#admin">Administrador</a>
+                        <a href="#manager">Gerente</a>
+                        <a href="#supervisor">Supervisor</a>
+                        <a href="#consultant">Consultor</a>
+                        <a href="#technician">Técnico</a>
+                        <a href="#matrix">Matriz de Permisos</a>
+                    </nav>
+                </div>
+            </aside>
+
+            <main class="docs-main">
+                <section id="overview" class="docs-section">
+                    <h2>Visión General del Sistema RBAC</h2>
+                    <p>PráticOS utiliza un sistema de control de acceso basado en perfiles (<strong>RBAC - Role-Based Access Control</strong>) para gestionar los permisos de los colaboradores de cada empresa.</p>
+                    <div class="info-card">
+                        <div class="info-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg></div>
+                        <div class="info-content">
+                            <h4>Multi-Tenancy</h4>
+                            <p>Un usuario puede tener perfiles diferentes en empresas diferentes. Por ejemplo, ser Administrador en una empresa y Técnico en otra.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="profiles" class="docs-section">
+                    <h2>Perfiles Disponibles</h2>
+                    <p>El sistema cuenta con 5 perfiles distintos, cada uno diseñado para atender diferentes funciones dentro de la organización:</p>
+                    <div class="profiles-grid">
+                        <a href="#admin" class="profile-card profile-admin">
+                            <div class="profile-icon"><span class="profile-emoji">&#128104;&#8205;&#128188;</span></div>
+                            <h3>Administrador</h3>
+                            <p>Acceso total al sistema</p>
+                            <span class="profile-tag">Gestión Completa</span>
+                        </a>
+                        <a href="#manager" class="profile-card profile-manager">
+                            <div class="profile-icon"><span class="profile-emoji">&#128176;</span></div>
+                            <h3>Gerente</h3>
+                            <p>Gestión financiera e informes</p>
+                            <span class="profile-tag">Financiero</span>
+                        </a>
+                        <a href="#supervisor" class="profile-card profile-supervisor">
+                            <div class="profile-icon"><span class="profile-emoji">&#129489;&#8205;&#128295;</span></div>
+                            <h3>Supervisor</h3>
+                            <p>Gestión operacional de técnicos</p>
+                            <span class="profile-tag">Operacional</span>
+                        </a>
+                        <a href="#consultant" class="profile-card profile-consultant">
+                            <div class="profile-icon"><span class="profile-emoji">&#129489;&#8205;&#128188;</span></div>
+                            <h3>Consultor</h3>
+                            <p>Ventas y seguimiento comercial</p>
+                            <span class="profile-tag">Comercial</span>
+                        </a>
+                        <a href="#technician" class="profile-card profile-technician">
+                            <div class="profile-icon"><span class="profile-emoji">&#128119;</span></div>
+                            <h3>Técnico</h3>
+                            <p>Ejecución de servicios en campo</p>
+                            <span class="profile-tag">Ejecución</span>
+                        </a>
+                    </div>
+                </section>
+
+                <section id="admin" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge admin">&#128104;&#8205;&#128188;</span>
+                        <div><h2>Administrador</h2><p class="section-subtitle">Acceso total al sistema. Responsable de la configuración de la empresa y gestión de todos los recursos.</p></div>
+                    </div>
+                    <div class="permissions-grid">
+                        <div class="permission-category">
+                            <h4><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg> Órdenes de Servicio</h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Ver todas las OS de la empresa</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Crear nuevas OS</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Editar cualquier OS</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Asignar/reasignar técnicos</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Ejecutar servicios</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Eliminar OS</li>
+                            </ul>
+                        </div>
+                        <div class="permission-category">
+                            <h4><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"></line><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path></svg> Datos Financieros</h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Ver valores y precios</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Ver facturación</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Acceder a informes financieros</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Editar valores y precios</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="manager" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge manager">&#128176;</span>
+                        <div><h2>Gerente (Financiero)</h2><p class="section-subtitle">Responsable de la gestión financiera de la empresa. Acceso completo a datos financieros e informes, pero sin interferir en la operación técnica.</p></div>
+                    </div>
+                </section>
+
+                <section id="supervisor" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge supervisor">&#129489;&#8205;&#128295;</span>
+                        <div><h2>Supervisor</h2><p class="section-subtitle">Responsable de la gestión operacional del equipo técnico. Coordina la distribución de trabajo y acompaña la ejecución de los servicios.</p></div>
+                    </div>
+                    <div class="warning-card">
+                        <div class="warning-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg></div>
+                        <div class="warning-content"><h4>Sin Acceso Financiero</h4><p>Este perfil no visualiza valores, precios, facturación ni informes financieros. Ideal para colaboradores enfocados en la operación.</p></div>
+                    </div>
+                </section>
+
+                <section id="consultant" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge consultant">&#129489;&#8205;&#128188;</span>
+                        <div><h2>Consultor (Vendedor)</h2><p class="section-subtitle">Perfil comercial enfocado en ventas y creación de presupuestos. Acceso limitado a sus propias OS y datos de clientes.</p></div>
+                    </div>
+                    <div class="info-card">
+                        <div class="info-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg></div>
+                        <div class="info-content"><h4>Visibilidad Limitada</h4><p>El Consultor solo visualiza las OS que él mismo creó. En caso de vacaciones o ausencia, el Administrador puede reasignar OS a otro consultor.</p></div>
+                    </div>
+                </section>
+
+                <section id="technician" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge technician">&#128119;</span>
+                        <div><h2>Técnico</h2><p class="section-subtitle">Responsable de la ejecución de los servicios en campo. Acceso a las Órdenes de Servicio de la empresa para ejecución y reporte.</p></div>
+                    </div>
+                    <div class="warning-card">
+                        <div class="warning-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg></div>
+                        <div class="warning-content"><h4>Perfil Operacional</h4><p>Enfoque en la ejecución. No visualiza valores financieros y tiene edición limitada en OS después de la aprobación.</p></div>
+                    </div>
+                </section>
+
+                <section id="matrix" class="docs-section">
+                    <h2>Matriz de Permisos</h2>
+                    <p>Visión consolidada de todos los permisos por perfil:</p>
+                    <div class="table-wrapper">
+                        <h4>Órdenes de Servicio</h4>
+                        <table class="permissions-table">
+                            <thead><tr><th>Permiso</th><th>Admin</th><th>Gerente</th><th>Supervisor</th><th>Consultor</th><th>Técnico</th></tr></thead>
+                            <tbody>
+                                <tr><td>Ver todas las OS</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td></tr>
+                                <tr><td>Crear OS</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td></tr>
+                                <tr><td>Asignar técnicos</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="no">&#10007;</td></tr>
+                                <tr><td>Ejecutar OS</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="table-wrapper">
+                        <h4>Datos Financieros</h4>
+                        <table class="permissions-table">
+                            <thead><tr><th>Permiso</th><th>Admin</th><th>Gerente</th><th>Supervisor</th><th>Consultor</th><th>Técnico</th></tr></thead>
+                            <tbody>
+                                <tr><td>Ver precios</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td></tr>
+                                <tr><td>Ver facturación</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="no">&#10007;</td><td class="no">&#10007;</td></tr>
+                                <tr><td>Informes financieros</td><td class="yes">&#10003;</td><td class="yes">&#10003;</td><td class="no">&#10007;</td><td class="no">&#10007;</td><td class="no">&#10007;</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <div class="docs-navigation">
+                    <a href="index-es.html" class="nav-link prev"><span class="nav-direction">&#8592; Volver</span><span class="nav-title">Documentación</span></a>
+                    <a href="../support-es.html" class="nav-link next"><span class="nav-direction">Siguiente &#8594;</span><span class="nav-title">Soporte</span></a>
+                </div>
+            </main>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-bottom">
+                <p>&copy; 2025 PráticOS. Todos los derechos reservados.</p>
+                <p>Desarrollado por <a href="https://www.rafsoft.com.br" target="_blank" rel="noopener">Rafsoft</a></p>
+            </div>
+        </div>
+    </footer>
+
+    <div class="mobile-menu">
+        <div class="mobile-menu-content">
+            <a href="../index-es.html">Inicio</a>
+            <a href="index-es.html">Documentación</a>
+            <a href="../faq-es.html">FAQ</a>
+            <a href="../support-es.html">Soporte</a>
+            <div class="mobile-lang"><a href="perfis.html">PT</a><a href="perfis-en.html">EN</a><a href="perfis-es.html" class="active">ES</a></div>
+            <a href="../index-es.html#download" class="btn btn-primary">Descargar App</a>
+        </div>
+    </div>
+
+    <script>
+        const navToggle = document.querySelector('.nav-toggle');
+        const mobileMenu = document.querySelector('.mobile-menu');
+        const body = document.body;
+        navToggle.addEventListener('click', () => { navToggle.classList.toggle('active'); mobileMenu.classList.toggle('active'); body.classList.toggle('menu-open'); });
+        mobileMenu.querySelectorAll('a').forEach(link => { link.addEventListener('click', () => { navToggle.classList.remove('active'); mobileMenu.classList.remove('active'); body.classList.remove('menu-open'); }); });
+
+        const sections = document.querySelectorAll('.docs-section');
+        const navLinks = document.querySelectorAll('.docs-nav a');
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    navLinks.forEach(link => link.classList.remove('active'));
+                    const activeLink = document.querySelector(`.docs-nav a[href="#${entry.target.id}"]`);
+                    if (activeLink) activeLink.classList.add('active');
+                }
+            });
+        }, { rootMargin: '-100px 0px -70% 0px', threshold: 0 });
+        sections.forEach(section => observer.observe(section));
+
+        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+            anchor.addEventListener('click', function(e) {
+                e.preventDefault();
+                const target = document.querySelector(this.getAttribute('href'));
+                if (target) { window.scrollTo({ top: target.getBoundingClientRect().top + window.pageYOffset - 100, behavior: 'smooth' }); }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/firebase/hosting/public/docs/perfis.html
+++ b/firebase/hosting/public/docs/perfis.html
@@ -1,0 +1,1097 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Perfis de Usuários - PráticOS Documentação</title>
+    <meta name="description" content="Documentação completa sobre os perfis de usuários e permissões do sistema PráticOS. Conheça as funcionalidades de cada perfil.">
+    <meta name="keywords" content="praticos, documentação, perfis, permissões, RBAC, usuários, administrador, gerente, supervisor, técnico">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Perfis de Usuários - PráticOS">
+    <meta property="og:description" content="Documentação completa sobre os perfis de usuários e permissões do sistema PráticOS.">
+    <meta property="og:image" content="../assets/images/logo.png">
+    <meta property="og:type" content="article">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="../assets/images/logo.png">
+
+    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="docs.css">
+</head>
+
+<body>
+    <!-- Navigation -->
+    <nav class="navbar scrolled">
+        <div class="nav-container">
+            <a href="../index.html" class="nav-logo">
+                <img src="../assets/images/logo.png" alt="PráticOS" class="logo-img">
+                <span class="logo-text">Prát<span class="yellow">ic</span><span class="accent">OS</span></span>
+            </a>
+            <div class="nav-links">
+                <a href="../index.html">Início</a>
+                <a href="../index.html#features">Funcionalidades</a>
+                <a href="index.html" class="active">Documentação</a>
+                <a href="../faq.html">FAQ</a>
+                <a href="../support.html">Suporte</a>
+            </div>
+            <div class="nav-actions">
+                <div class="lang-switch">
+                    <a href="perfis.html" class="active">PT</a>
+                    <a href="perfis-en.html">EN</a>
+                    <a href="perfis-es.html">ES</a>
+                </div>
+                <a href="../index.html#download" class="btn btn-primary">Baixar App</a>
+            </div>
+            <button class="nav-toggle" aria-label="Menu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+    </nav>
+
+    <!-- Page Header -->
+    <section class="docs-hero compact">
+        <div class="hero-bg">
+            <div class="gradient-orb orb-1"></div>
+            <div class="gradient-orb orb-2"></div>
+        </div>
+        <div class="container">
+            <div class="docs-breadcrumb">
+                <a href="index.html">Documentação</a>
+                <span>/</span>
+                <span>Perfis de Usuários</span>
+            </div>
+            <div class="docs-hero-content">
+                <h1>Perfis de <span class="gradient-text">Usuários</span></h1>
+                <p class="hero-subtitle">Conheça os diferentes perfis disponíveis no PráticOS e suas permissões específicas para cada função na sua empresa.</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Docs Content -->
+    <section class="docs-content">
+        <div class="container docs-container">
+            <!-- Sidebar Navigation -->
+            <aside class="docs-sidebar">
+                <div class="sidebar-sticky">
+                    <h4>Nesta página</h4>
+                    <nav class="docs-nav">
+                        <a href="#visao-geral" class="active">Visão Geral</a>
+                        <a href="#perfis">Perfis Disponíveis</a>
+                        <a href="#admin">Administrador</a>
+                        <a href="#gerente">Gerente</a>
+                        <a href="#supervisor">Supervisor</a>
+                        <a href="#consultor">Consultor</a>
+                        <a href="#tecnico">Técnico</a>
+                        <a href="#matriz">Matriz de Permissões</a>
+                        <a href="#status">Regras por Status</a>
+                        <a href="#faq">Perguntas Frequentes</a>
+                    </nav>
+                </div>
+            </aside>
+
+            <!-- Main Content -->
+            <main class="docs-main">
+                <!-- Visão Geral -->
+                <section id="visao-geral" class="docs-section">
+                    <h2>Visão Geral do Sistema RBAC</h2>
+                    <p>O PráticOS utiliza um sistema de controle de acesso baseado em perfis (<strong>RBAC - Role-Based Access Control</strong>) para gerenciar as permissões dos colaboradores de cada empresa.</p>
+
+                    <div class="info-card">
+                        <div class="info-icon">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <circle cx="12" cy="12" r="10"></circle>
+                                <line x1="12" y1="16" x2="12" y2="12"></line>
+                                <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                            </svg>
+                        </div>
+                        <div class="info-content">
+                            <h4>Multi-Tenancy</h4>
+                            <p>Um usuário pode ter perfis diferentes em empresas diferentes. Por exemplo, ser Administrador em uma empresa e Técnico em outra.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Perfis Disponíveis -->
+                <section id="perfis" class="docs-section">
+                    <h2>Perfis Disponíveis</h2>
+                    <p>O sistema conta com 5 perfis distintos, cada um projetado para atender diferentes funções dentro da organização:</p>
+
+                    <div class="profiles-grid">
+                        <a href="#admin" class="profile-card profile-admin">
+                            <div class="profile-icon">
+                                <span class="profile-emoji">&#128104;&#8205;&#128188;</span>
+                            </div>
+                            <h3>Administrador</h3>
+                            <p>Acesso total ao sistema</p>
+                            <span class="profile-tag">Gestão Completa</span>
+                        </a>
+
+                        <a href="#gerente" class="profile-card profile-manager">
+                            <div class="profile-icon">
+                                <span class="profile-emoji">&#128176;</span>
+                            </div>
+                            <h3>Gerente</h3>
+                            <p>Gestão financeira e relatórios</p>
+                            <span class="profile-tag">Financeiro</span>
+                        </a>
+
+                        <a href="#supervisor" class="profile-card profile-supervisor">
+                            <div class="profile-icon">
+                                <span class="profile-emoji">&#129489;&#8205;&#128295;</span>
+                            </div>
+                            <h3>Supervisor</h3>
+                            <p>Gestão operacional dos técnicos</p>
+                            <span class="profile-tag">Operacional</span>
+                        </a>
+
+                        <a href="#consultor" class="profile-card profile-consultant">
+                            <div class="profile-icon">
+                                <span class="profile-emoji">&#129489;&#8205;&#128188;</span>
+                            </div>
+                            <h3>Consultor</h3>
+                            <p>Vendas e acompanhamento comercial</p>
+                            <span class="profile-tag">Comercial</span>
+                        </a>
+
+                        <a href="#tecnico" class="profile-card profile-technician">
+                            <div class="profile-icon">
+                                <span class="profile-emoji">&#128119;</span>
+                            </div>
+                            <h3>Técnico</h3>
+                            <p>Execução de serviços em campo</p>
+                            <span class="profile-tag">Execução</span>
+                        </a>
+                    </div>
+                </section>
+
+                <!-- Administrador -->
+                <section id="admin" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge admin">&#128104;&#8205;&#128188;</span>
+                        <div>
+                            <h2>Administrador</h2>
+                            <p class="section-subtitle">Acesso total ao sistema. Responsável pela configuração da empresa e gestão de todos os recursos.</p>
+                        </div>
+                    </div>
+
+                    <div class="permissions-grid">
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                                    <polyline points="14 2 14 8 20 8"></polyline>
+                                </svg>
+                                Ordens de Serviço
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar todas as OS da empresa</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Criar novas OS</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Editar qualquer OS</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Atribuir/reatribuir técnicos</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Executar serviços</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Deletar OS</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <line x1="12" y1="1" x2="12" y2="23"></line>
+                                    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                                </svg>
+                                Dados Financeiros
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar valores e preços</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar faturamento</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Acessar relatórios financeiros</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Editar valores e preços</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                                    <circle cx="9" cy="7" r="4"></circle>
+                                    <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                                    <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                                </svg>
+                                Cadastros
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar clientes</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar produtos</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar serviços</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar dispositivos</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <circle cx="12" cy="12" r="3"></circle>
+                                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                                </svg>
+                                Administração
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar usuários e colaboradores</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar perfis e permissões</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Configurar dados da empresa</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Configurar parâmetros globais</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Gerente -->
+                <section id="gerente" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge manager">&#128176;</span>
+                        <div>
+                            <h2>Gerente (Financeiro)</h2>
+                            <p class="section-subtitle">Responsável pela gestão financeira da empresa. Acesso completo a dados financeiros e relatórios, mas sem interferir na operação técnica.</p>
+                        </div>
+                    </div>
+
+                    <div class="permissions-grid">
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                                    <polyline points="14 2 14 8 20 8"></polyline>
+                                </svg>
+                                Ordens de Serviço
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar todas as OS</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Criar novas OS</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Editar OS (ajustes fiscais/financeiros)</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Atribuir técnicos</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Executar serviços</li>
+                                <li class="partial"><span class="icon">&#9888;</span> Deletar OS (apenas status 'Orçamento')</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <line x1="12" y1="1" x2="12" y2="23"></line>
+                                    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                                </svg>
+                                Dados Financeiros
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar valores e preços</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar faturamento</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Acessar relatórios financeiros</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Editar valores e preços</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                                    <circle cx="9" cy="7" r="4"></circle>
+                                </svg>
+                                Cadastros
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar clientes</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar produtos</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar serviços</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar dispositivos</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Gerenciar outros cadastros</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <line x1="18" y1="20" x2="18" y2="10"></line>
+                                    <line x1="12" y1="20" x2="12" y2="4"></line>
+                                    <line x1="6" y1="20" x2="6" y2="14"></line>
+                                </svg>
+                                Relatórios
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Relatórios operacionais</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Dashboard geral</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Reabrir procedimentos concluídos</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Supervisor -->
+                <section id="supervisor" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge supervisor">&#129489;&#8205;&#128295;</span>
+                        <div>
+                            <h2>Supervisor</h2>
+                            <p class="section-subtitle">Responsável pela gestão operacional da equipe técnica. Coordena a distribuição de trabalho e acompanha a execução dos serviços.</p>
+                        </div>
+                    </div>
+
+                    <div class="warning-card">
+                        <div class="warning-icon">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+                                <line x1="12" y1="9" x2="12" y2="13"></line>
+                                <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                            </svg>
+                        </div>
+                        <div class="warning-content">
+                            <h4>Sem Acesso Financeiro</h4>
+                            <p>Este perfil não visualiza valores, preços, faturamento ou relatórios financeiros. Ideal para colaboradores que focam na operação.</p>
+                        </div>
+                    </div>
+
+                    <div class="permissions-grid">
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                                    <polyline points="14 2 14 8 20 8"></polyline>
+                                </svg>
+                                Ordens de Serviço
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar todas as OS (sem valores)</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Criar novas OS</li>
+                                <li class="partial"><span class="icon">&#9888;</span> Editar OS completa (apenas status 'Orçamento')</li>
+                                <li class="partial"><span class="icon">&#9888;</span> Editar observações (após 'Orçamento')</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Atribuir/reatribuir técnicos</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Executar serviços</li>
+                                <li class="partial"><span class="icon">&#9888;</span> Deletar OS (apenas status 'Orçamento')</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <line x1="12" y1="1" x2="12" y2="23"></line>
+                                    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                                </svg>
+                                Dados Financeiros
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="denied"><span class="icon">&#10007;</span> Visualizar valores e preços</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Visualizar faturamento</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Acessar relatórios financeiros</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Gerar PDF de OS</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Filtros de pagamento ocultos</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                                    <circle cx="9" cy="7" r="4"></circle>
+                                </svg>
+                                Cadastros
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar clientes</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Gerenciar produtos (sem ver preços)</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Gerenciar serviços (sem ver preços)</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar dispositivos</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M9 11l3 3L22 4"></path>
+                                    <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
+                                </svg>
+                                Formulários/Procedimentos
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Preencher formulários</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar templates de formulários</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Reabrir procedimentos concluídos</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Adicionar/remover procedimentos em OS ativa</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Consultor -->
+                <section id="consultor" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge consultant">&#129489;&#8205;&#128188;</span>
+                        <div>
+                            <h2>Consultor (Vendedor)</h2>
+                            <p class="section-subtitle">Perfil comercial focado em vendas e criação de orçamentos. Acesso limitado às suas próprias OS e dados de clientes.</p>
+                        </div>
+                    </div>
+
+                    <div class="info-card">
+                        <div class="info-icon">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <circle cx="12" cy="12" r="10"></circle>
+                                <line x1="12" y1="16" x2="12" y2="12"></line>
+                                <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                            </svg>
+                        </div>
+                        <div class="info-content">
+                            <h4>Visibilidade Limitada</h4>
+                            <p>O Consultor só visualiza as OS que ele mesmo criou. Em caso de férias ou ausência, o Administrador pode reatribuir OS para outro consultor.</p>
+                        </div>
+                    </div>
+
+                    <div class="permissions-grid">
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                                    <polyline points="14 2 14 8 20 8"></polyline>
+                                </svg>
+                                Ordens de Serviço
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="partial"><span class="icon">&#9888;</span> Visualizar apenas OS que criou</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Criar novas OS</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Editar suas próprias OS</li>
+                                <li class="partial"><span class="icon">&#9888;</span> Deletar OS que criou (status 'Orçamento')</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Atribuir técnicos</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Executar serviços</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <line x1="12" y1="1" x2="12" y2="23"></line>
+                                    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                                </svg>
+                                Dados Financeiros
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar valores e preços (para orçamentos)</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Visualizar faturamento geral</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Acessar relatórios financeiros</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Editar valores e preços</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                                    <circle cx="9" cy="7" r="4"></circle>
+                                </svg>
+                                Cadastros
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Gerenciar clientes</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar produtos</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar serviços</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar dispositivos</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M9 11l3 3L22 4"></path>
+                                    <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
+                                </svg>
+                                Formulários/Procedimentos
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Preencher formulários</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Gerenciar templates</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Reabrir procedimentos concluídos</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Técnico -->
+                <section id="tecnico" class="docs-section">
+                    <div class="section-header-inline">
+                        <span class="profile-badge technician">&#128119;</span>
+                        <div>
+                            <h2>Técnico</h2>
+                            <p class="section-subtitle">Responsável pela execução dos serviços em campo. Acesso às Ordens de Serviço da empresa para execução e reporte.</p>
+                        </div>
+                    </div>
+
+                    <div class="warning-card">
+                        <div class="warning-icon">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+                                <line x1="12" y1="9" x2="12" y2="13"></line>
+                                <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                            </svg>
+                        </div>
+                        <div class="warning-content">
+                            <h4>Perfil Operacional</h4>
+                            <p>Foco na execução. Não visualiza valores financeiros e tem edição limitada em OS após aprovação.</p>
+                        </div>
+                    </div>
+
+                    <div class="permissions-grid">
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                                    <polyline points="14 2 14 8 20 8"></polyline>
+                                </svg>
+                                Ordens de Serviço
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar todas as OS (sem valores)</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Criar novas OS (inicia em 'Orçamento')</li>
+                                <li class="partial"><span class="icon">&#9888;</span> Editar OS completa (apenas status 'Orçamento')</li>
+                                <li class="partial"><span class="icon">&#9888;</span> Editar observações (após 'Orçamento')</li>
+                                <li class="partial"><span class="icon">&#9888;</span> Deletar OS que criou (status 'Orçamento')</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Atribuir técnicos</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Executar serviços</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <line x1="12" y1="1" x2="12" y2="23"></line>
+                                    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                                </svg>
+                                Dados Financeiros
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="denied"><span class="icon">&#10007;</span> Visualizar valores e preços</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Visualizar faturamento</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Acessar relatórios financeiros</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Gerar PDF de OS</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                                    <circle cx="9" cy="7" r="4"></circle>
+                                </svg>
+                                Cadastros
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar clientes (para contato)</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Gerenciar clientes</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Visualizar produtos (valores ocultos)</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Visualizar serviços (valores ocultos)</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Visualizar dispositivos</li>
+                            </ul>
+                        </div>
+
+                        <div class="permission-category">
+                            <h4>
+                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M9 11l3 3L22 4"></path>
+                                    <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
+                                </svg>
+                                Formulários/Procedimentos
+                            </h4>
+                            <ul class="permission-list">
+                                <li class="allowed"><span class="icon">&#10003;</span> Preencher formulários e checklists</li>
+                                <li class="allowed"><span class="icon">&#10003;</span> Anexar fotos às OS</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Gerenciar templates</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Reabrir procedimentos concluídos</li>
+                                <li class="denied"><span class="icon">&#10007;</span> Adicionar/remover procedimentos (após 'Orçamento')</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Matriz de Permissões -->
+                <section id="matriz" class="docs-section">
+                    <h2>Matriz de Permissões</h2>
+                    <p>Visão consolidada de todas as permissões por perfil:</p>
+
+                    <div class="table-wrapper">
+                        <h4>Ordens de Serviço</h4>
+                        <table class="permissions-table">
+                            <thead>
+                                <tr>
+                                    <th>Permissão</th>
+                                    <th>Admin</th>
+                                    <th>Gerente</th>
+                                    <th>Supervisor</th>
+                                    <th>Consultor</th>
+                                    <th>Técnico</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Ver todas as OS</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="yes">&#10003;</td>
+                                </tr>
+                                <tr>
+                                    <td>Criar OS</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                </tr>
+                                <tr>
+                                    <td>Editar OS</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="partial">*</td>
+                                    <td class="partial">*</td>
+                                    <td class="partial">*</td>
+                                </tr>
+                                <tr>
+                                    <td>Atribuir técnicos</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                                <tr>
+                                    <td>Executar OS</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="yes">&#10003;</td>
+                                </tr>
+                                <tr>
+                                    <td>Deletar OS</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="partial">*</td>
+                                    <td class="partial">*</td>
+                                    <td class="partial">*</td>
+                                    <td class="partial">*</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <p class="table-note">* Restrições baseadas em status e propriedade da OS. Veja detalhes nas seções de cada perfil.</p>
+                    </div>
+
+                    <div class="table-wrapper">
+                        <h4>Dados Financeiros</h4>
+                        <table class="permissions-table">
+                            <thead>
+                                <tr>
+                                    <th>Permissão</th>
+                                    <th>Admin</th>
+                                    <th>Gerente</th>
+                                    <th>Supervisor</th>
+                                    <th>Consultor</th>
+                                    <th>Técnico</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Ver preços</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                                <tr>
+                                    <td>Ver faturamento</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                                <tr>
+                                    <td>Relatórios financeiros</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                                <tr>
+                                    <td>Editar preços</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="table-wrapper">
+                        <h4>Cadastros</h4>
+                        <table class="permissions-table">
+                            <thead>
+                                <tr>
+                                    <th>Permissão</th>
+                                    <th>Admin</th>
+                                    <th>Gerente</th>
+                                    <th>Supervisor</th>
+                                    <th>Consultor</th>
+                                    <th>Técnico</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Gerenciar clientes</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                                <tr>
+                                    <td>Gerenciar produtos</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                                <tr>
+                                    <td>Gerenciar serviços</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                                <tr>
+                                    <td>Gerenciar dispositivos</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="table-wrapper">
+                        <h4>Formulários e Procedimentos</h4>
+                        <table class="permissions-table">
+                            <thead>
+                                <tr>
+                                    <th>Permissão</th>
+                                    <th>Admin</th>
+                                    <th>Gerente</th>
+                                    <th>Supervisor</th>
+                                    <th>Consultor</th>
+                                    <th>Técnico</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Preencher procedimentos</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                </tr>
+                                <tr>
+                                    <td>Gerenciar templates</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                                <tr>
+                                    <td>Reabrir concluídos</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="yes">&#10003;</td>
+                                    <td class="no">&#10007;</td>
+                                    <td class="no">&#10007;</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <!-- Regras por Status -->
+                <section id="status" class="docs-section">
+                    <h2>Regras Baseadas em Status da OS</h2>
+                    <p>As permissões de edição variam conforme o status atual da OS:</p>
+
+                    <div class="status-flow">
+                        <div class="status-item status-quote">
+                            <span class="status-dot"></span>
+                            <span class="status-name">Orçamento</span>
+                        </div>
+                        <div class="status-arrow">&#8594;</div>
+                        <div class="status-item status-approved">
+                            <span class="status-dot"></span>
+                            <span class="status-name">Aprovado</span>
+                        </div>
+                        <div class="status-arrow">&#8594;</div>
+                        <div class="status-item status-progress">
+                            <span class="status-dot"></span>
+                            <span class="status-name">Em Andamento</span>
+                        </div>
+                        <div class="status-arrow">&#8594;</div>
+                        <div class="status-item status-done">
+                            <span class="status-dot"></span>
+                            <span class="status-name">Concluído</span>
+                        </div>
+                    </div>
+
+                    <div class="status-details">
+                        <div class="status-card">
+                            <h4>
+                                <span class="status-indicator quote"></span>
+                                Status 'Orçamento'
+                            </h4>
+                            <p>Supervisor e Técnico têm permissões completas de edição:</p>
+                            <ul>
+                                <li>Adicionar/editar/remover serviços e produtos</li>
+                                <li>Adicionar/remover procedimentos</li>
+                                <li>Alterar cliente e dispositivo</li>
+                                <li>Alterar data de entrega</li>
+                                <li>Adicionar fotos</li>
+                            </ul>
+                            <p class="note"><strong>Nota:</strong> Valores financeiros permanecem ocultos para perfis sem acesso financeiro.</p>
+                        </div>
+
+                        <div class="status-card">
+                            <h4>
+                                <span class="status-indicator approved"></span>
+                                Após Aprovação
+                            </h4>
+                            <p>Restrições se aplicam para Supervisor e Técnico:</p>
+
+                            <div class="status-permissions">
+                                <div class="can-do">
+                                    <h5>&#10003; Pode</h5>
+                                    <ul>
+                                        <li>Editar descrição/observações de serviços</li>
+                                        <li>Preencher procedimentos existentes</li>
+                                        <li>Adicionar fotos</li>
+                                        <li>Supervisor: Adicionar/remover procedimentos</li>
+                                        <li>Supervisor: Atribuir/reatribuir técnicos</li>
+                                    </ul>
+                                </div>
+                                <div class="cannot-do">
+                                    <h5>&#10007; Não Pode</h5>
+                                    <ul>
+                                        <li>Adicionar novos serviços ou produtos</li>
+                                        <li>Remover serviços ou produtos</li>
+                                        <li>Editar valores ou quantidades</li>
+                                        <li>Alterar cliente ou dispositivo</li>
+                                        <li>Alterar data de entrega</li>
+                                        <li>Gerar PDF da OS</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="status-card">
+                            <h4>
+                                <span class="status-indicator done"></span>
+                                Status 'Concluído'
+                            </h4>
+                            <p>Apenas <strong>Admin</strong> e <strong>Gerente</strong> podem alterar o status de uma OS concluída.</p>
+                            <p>Consultor, Supervisor e Técnico não podem fazer alterações em OS concluídas, garantindo integridade do histórico.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- FAQ -->
+                <section id="faq" class="docs-section">
+                    <h2>Perguntas Frequentes</h2>
+
+                    <div class="faq-grid">
+                        <div class="faq-item">
+                            <h4>Um usuário pode ter perfis diferentes em empresas diferentes?</h4>
+                            <p>Sim. O sistema suporta multi-tenancy, onde um usuário pode ser Admin em uma empresa e Técnico em outra.</p>
+                        </div>
+
+                        <div class="faq-item">
+                            <h4>O que acontece se um perfil não for reconhecido?</h4>
+                            <p>O sistema normaliza para "técnico" (menor privilégio) por segurança.</p>
+                        </div>
+
+                        <div class="faq-item">
+                            <h4>Como adicionar um novo colaborador?</h4>
+                            <p>Apenas Administradores podem adicionar colaboradores através de <strong>Ajustes > Colaboradores > Adicionar</strong>.</p>
+                        </div>
+
+                        <div class="faq-item">
+                            <h4>Os valores financeiros ficam realmente ocultos para técnicos?</h4>
+                            <p>Sim. A proteção é feita em múltiplas camadas: UI (widgets), lógica (filtros) e backend (security rules).</p>
+                        </div>
+
+                        <div class="faq-item">
+                            <h4>Um Técnico pode aprovar sua própria OS?</h4>
+                            <p>Sim. Se o Técnico (ou Supervisor) criar uma OS, ele pode avançar o status de "Orçamento" para "Aprovado" ou "Em Andamento" diretamente.</p>
+                        </div>
+
+                        <div class="faq-item">
+                            <h4>Quem pode reabrir um procedimento concluído?</h4>
+                            <p>Apenas <strong>Admin</strong>, <strong>Gerente</strong> e <strong>Supervisor</strong>. Consultor e Técnico não têm essa permissão.</p>
+                        </div>
+
+                        <div class="faq-item">
+                            <h4>Admin pode reverter o status de uma OS concluída?</h4>
+                            <p>Sim. Admin e Gerente são os únicos perfis que podem alterar o status de uma OS concluída, permitindo reabrir ou corrigir quando necessário.</p>
+                        </div>
+
+                        <div class="faq-item">
+                            <h4>Por que Supervisor e Técnico têm restrições similares?</h4>
+                            <p>Ambos são perfis operacionais sem acesso financeiro. A diferença é que Supervisor pode gerenciar dispositivos, reabrir formulários e adicionar procedimentos em OS ativas.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Navigation -->
+                <div class="docs-navigation">
+                    <a href="index.html" class="nav-link prev">
+                        <span class="nav-direction">&#8592; Voltar</span>
+                        <span class="nav-title">Documentação</span>
+                    </a>
+                    <a href="../support.html" class="nav-link next">
+                        <span class="nav-direction">Próximo &#8594;</span>
+                        <span class="nav-title">Suporte</span>
+                    </a>
+                </div>
+            </main>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-brand">
+                    <a href="../index.html" class="nav-logo">
+                        <img src="../assets/images/logo.png" alt="PráticOS" class="logo-img">
+                        <span class="logo-text">Prát<span class="yellow">ic</span><span class="accent">OS</span></span>
+                    </a>
+                    <p>Sistema completo para gestão de ordens de serviço. Simplifique seu negócio.</p>
+                </div>
+                <div class="footer-links">
+                    <h4>Produto</h4>
+                    <a href="../index.html#features">Funcionalidades</a>
+                    <a href="../index.html#pricing">Planos</a>
+                    <a href="../index.html#download">Download</a>
+                </div>
+                <div class="footer-links">
+                    <h4>Documentação</h4>
+                    <a href="perfis.html">Perfis de Usuários</a>
+                    <a href="../faq.html">FAQ</a>
+                    <a href="../support.html">Suporte</a>
+                </div>
+                <div class="footer-links">
+                    <h4>Legal</h4>
+                    <a href="../privacy.html">Privacidade</a>
+                    <a href="../terms.html">Termos de Uso</a>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2025 PráticOS. Todos os direitos reservados.</p>
+                <p>Desenvolvido por <a href="https://www.rafsoft.com.br" target="_blank" rel="noopener">Rafsoft</a></p>
+            </div>
+        </div>
+    </footer>
+
+    <!-- Mobile Menu -->
+    <div class="mobile-menu">
+        <div class="mobile-menu-content">
+            <a href="../index.html">Início</a>
+            <a href="../index.html#features">Funcionalidades</a>
+            <a href="index.html">Documentação</a>
+            <a href="../faq.html">FAQ</a>
+            <a href="../support.html">Suporte</a>
+            <div class="mobile-lang">
+                <a href="perfis.html" class="active">PT</a>
+                <a href="perfis-en.html">EN</a>
+                <a href="perfis-es.html">ES</a>
+            </div>
+            <a href="../index.html#download" class="btn btn-primary">Baixar App</a>
+        </div>
+    </div>
+
+    <script>
+        // Mobile menu toggle
+        const navToggle = document.querySelector('.nav-toggle');
+        const mobileMenu = document.querySelector('.mobile-menu');
+        const body = document.body;
+
+        navToggle.addEventListener('click', () => {
+            navToggle.classList.toggle('active');
+            mobileMenu.classList.toggle('active');
+            body.classList.toggle('menu-open');
+        });
+
+        // Close mobile menu on link click
+        mobileMenu.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', () => {
+                navToggle.classList.remove('active');
+                mobileMenu.classList.remove('active');
+                body.classList.remove('menu-open');
+            });
+        });
+
+        // Sidebar navigation active state
+        const sections = document.querySelectorAll('.docs-section');
+        const navLinks = document.querySelectorAll('.docs-nav a');
+
+        const observerOptions = {
+            rootMargin: '-100px 0px -70% 0px',
+            threshold: 0
+        };
+
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    navLinks.forEach(link => link.classList.remove('active'));
+                    const activeLink = document.querySelector(`.docs-nav a[href="#${entry.target.id}"]`);
+                    if (activeLink) activeLink.classList.add('active');
+                }
+            });
+        }, observerOptions);
+
+        sections.forEach(section => observer.observe(section));
+
+        // Smooth scroll for anchor links
+        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+            anchor.addEventListener('click', function(e) {
+                e.preventDefault();
+                const target = document.querySelector(this.getAttribute('href'));
+                if (target) {
+                    const offset = 100;
+                    const targetPosition = target.getBoundingClientRect().top + window.pageYOffset - offset;
+                    window.scrollTo({
+                        top: targetPosition,
+                        behavior: 'smooth'
+                    });
+                }
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/firebase/hosting/public/index-en.html
+++ b/firebase/hosting/public/index-en.html
@@ -37,6 +37,7 @@
                 <a href="#features">Features</a>
                 <a href="#screenshots">Screenshots</a>
                 <a href="#pricing">Pricing</a>
+                <a href="docs/index-en.html">Documentation</a>
                 <a href="faq-en.html">FAQ</a>
                 <a href="#contact">Contact</a>
             </div>

--- a/firebase/hosting/public/index-es.html
+++ b/firebase/hosting/public/index-es.html
@@ -37,6 +37,7 @@
                 <a href="#features">Funcionalidades</a>
                 <a href="#screenshots">Capturas</a>
                 <a href="#pricing">Planes</a>
+                <a href="docs/index-es.html">Documentación</a>
                 <a href="faq-es.html">FAQ</a>
                 <a href="#contact">Contacto</a>
             </div>

--- a/firebase/hosting/public/index.html
+++ b/firebase/hosting/public/index.html
@@ -37,6 +37,7 @@
                 <a href="#features">Funcionalidades</a>
                 <a href="#screenshots">Screenshots</a>
                 <a href="#pricing">Planos</a>
+                <a href="docs/">Documentação</a>
                 <a href="faq.html">FAQ</a>
                 <a href="#contact">Contato</a>
             </div>
@@ -497,6 +498,7 @@
                 </div>
                 <div class="footer-links">
                     <h4>Suporte</h4>
+                    <a href="docs/">Documentação</a>
                     <a href="support.html">Central de Suporte</a>
                     <a href="faq.html">FAQ</a>
                     <a href="#contact">Contato</a>
@@ -521,6 +523,7 @@
             <a href="#features">Funcionalidades</a>
             <a href="#screenshots">Screenshots</a>
             <a href="#pricing">Planos</a>
+            <a href="docs/">Documentação</a>
             <a href="faq.html">FAQ</a>
             <a href="support.html">Suporte</a>
             <a href="#contact">Contato</a>


### PR DESCRIPTION
- Create docs/ folder structure for scalable documentation
- Add user profiles documentation page (docs/perfis.html) with:
  - RBAC system overview
  - 5 user profiles (Admin, Manager, Supervisor, Consultant, Technician)
  - Detailed permissions for each profile
  - Permission matrices for quick reference
  - Status-based restrictions explanation
  - FAQ section
- Add dedicated docs.css with premium dark theme styling
- Create English (docs/perfis-en.html) and Spanish (docs/perfis-es.html) versions
- Add documentation index pages for all 3 languages
- Update main site navigation to include Documentation link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a structured docs area with localized content and links from the main site.
> 
> - Adds `docs/` with `index.html`, `index-en.html`, `index-es.html` and shared `docs.css` (responsive layout, search, sidebar TOC, quick links)
> - Creates detailed "User Profiles" pages: `perfis.html`, `perfis-en.html`, `perfis-es.html` covering RBAC overview, permissions matrices, status-based rules, and FAQ
> - Updates main pages (`index.html`, `index-en.html`, `index-es.html`) and footer/mobile menus to include "Documentation" links
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 042d44b28e77e2e42cfde73725260b2fba5fbde1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->