### PR TITLE
refactor: change release workflow to trigger only on release candidate tags

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -3,7 +3,7 @@ name: Release Android
 on:
   push:
     tags:
-      - 'rc-v*'
+      - 'v*-rc'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -3,7 +3,7 @@ name: Release iOS
 on:
   push:
     tags:
-      - 'rc-v*'
+      - 'v*-rc'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- Remove automatic deployment on master branch merge
- Configure workflows to trigger only on 'rc-v*' tags
- Remove production deployment steps (App Store and Google Play production)
- Keep only beta/internal track deployment for release candidates
- Remove metadata/screenshot validation steps (no longer needed for RC)

Now deployments will only happen when creating a release candidate tag (e.g., rc-v1.0.0):
- iOS: Deploys to TestFlight
- Android: Deploys to Internal Track