### PR TITLE
feat: implement dual release workflow for RC and production tags

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -3,7 +3,7 @@ name: Release Android
 on:
   push:
     tags:
-      - 'v*-rc'
+      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -40,6 +40,18 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
+      # 🔍 Check for Metadata/Screenshot changes (only for production releases)
+      - name: Check for metadata changes
+        if: "!endsWith(github.ref, '-rc')"
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            screenshots:
+              - 'android/fastlane/metadata/android/*/images/**'
+            metadata:
+              - 'android/fastlane/metadata/**'
+
       # 🔐 Restore Secrets
       
       - name: Make gradlew executable
@@ -60,10 +72,25 @@ jobs:
         run: |
           echo "${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > android/app/google-services.json
 
-      # 🚀 Build + Upload to Internal Track (release candidate)
+      # 🚀 Build + Upload to Internal Track (apenas release candidate com -rc)
       - name: Fastlane Internal (Google Play)
+        if: endsWith(github.ref, '-rc')
         working-directory: android
         env:
           FASTLANE_SKIP_UPDATE_CHECK: "true"
           CI: "true"
         run: bundle exec fastlane internal
+
+      # 🚀 Build + Upload to Production (apenas tags v* sem -rc)
+      - name: Fastlane Release (Production)
+        if: "!endsWith(github.ref, '-rc')"
+        working-directory: android
+        env:
+          FASTLANE_SKIP_UPDATE_CHECK: "true"
+          CI: "true"
+        run: |
+          bundle exec fastlane deploy_with_metadata \
+            track:production \
+            skip_screenshots:${{ steps.filter.outputs.screenshots == 'false' }} \
+            skip_images:${{ steps.filter.outputs.screenshots == 'false' }} \
+            skip_metadata:${{ steps.filter.outputs.metadata == 'false' }}

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -3,7 +3,7 @@ name: Release iOS
 on:
   push:
     tags:
-      - 'v*-rc'
+      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -57,6 +57,18 @@ jobs:
         with:
           ruby-version: '3.2'
           bundler-cache: true
+
+      # 🔍 Check for Metadata/Screenshot changes (only for production releases)
+      - name: Check for metadata changes
+        if: "!endsWith(github.ref, '-rc')"
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            screenshots:
+              - 'ios/fastlane/screenshots/**'
+            metadata:
+              - 'ios/fastlane/metadata/**'
 
       # 🔐 Importa o certificado .p12 no keychain
       - name: Import distribution cert
@@ -114,8 +126,9 @@ jobs:
           /usr/bin/plutil -lint GoogleService-Info.plist
           echo "GoogleService-Info.plist criado em ios/"
 
-      # 🚀 Build + upload para TestFlight (release candidate)
+      # 🚀 Build + upload para TestFlight (apenas release candidate com -rc)
       - name: Fastlane Beta (TestFlight)
+        if: endsWith(github.ref, '-rc')
         working-directory: ios
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -128,6 +141,25 @@ jobs:
           FASTLANE_SKIP_UPDATE_CHECK: "true"
           CI: "true"
         run: bundle exec fastlane beta
+
+      # 🚀 Build + upload para App Store (apenas tags v* sem -rc)
+      - name: Fastlane Release (App Store)
+        if: "!endsWith(github.ref, '-rc')"
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_PRIVATE_KEY }}
+          BUNDLE_ID: ${{ env.BUNDLE_ID }}
+          DEVELOPMENT_TEAM: ${{ env.DEVELOPMENT_TEAM }}
+          PROFILE_UUID: ${{ env.PROFILE_UUID }}
+          PROFILE_NAME: ${{ env.PROFILE_NAME }}
+          FASTLANE_SKIP_UPDATE_CHECK: "true"
+          CI: "true"
+        run: |
+          bundle exec fastlane release_store \
+            skip_screenshots:${{ steps.filter.outputs.screenshots == 'false' }} \
+            skip_metadata:${{ steps.filter.outputs.metadata == 'false' }}
 
       - name: Upload fastlane logs (on failure)
         if: failure()


### PR DESCRIPTION
Configure workflows to support two deployment paths:
- Tags v*-rc (e.g., v1.0.0-rc): Deploy to test environments
  * iOS: TestFlight
  * Android: Internal Track
- Tags v* (e.g., v1.0.0): Deploy to production
  * iOS: App Store
  * Android: Google Play Production

Changes:
- Trigger workflows on all v* tags (includes v*-rc)
- Add conditionals using endsWith(github.ref, '-rc') to distinguish paths
- Restore metadata/screenshot validation for production releases only
- Remove automatic deployment on master branch push