### PR TITLE
refactor: redesign order list items following Apple HIG guidelines

### DIFF
--- a/lib/providers/segment_config_provider.dart
+++ b/lib/providers/segment_config_provider.dart
@@ -25,6 +25,15 @@ class SegmentConfigProvider extends ChangeNotifier {
   /// Idioma atual
   String get locale => _service.currentLocale;
 
+  /// Define se o device deve ser exibido na listagem de OS
+  /// Por enquanto, true para todos os segmentos
+  bool get showDeviceInOrderList {
+    // TODO: Configurar por segmento quando necessário
+    // Segmentos onde device é importante: automotive, hvac, smartphones, computers, appliances, printers
+    // Segmentos onde device é menos relevante: electrical, plumbing, security, solar, other
+    return true;
+  }
+
   /// Obtém o ícone do dispositivo baseado no segmento
   IconData get deviceIcon {
     switch (segmentId) {


### PR DESCRIPTION
## Summary
- Redesigned order list items (`_buildOrderItem`) to follow Apple Human Interface Guidelines
- Added thumbnail (48pt) with status dot overlay at bottom-right corner
- Reorganized layout to 3 lines with proper typography hierarchy
- Added segment-specific device icons for placeholder thumbnails
- Replaced Material InkWell with CupertinoButton for native iOS feedback

## Changes
- **Thumbnail**: 48x48 with rounded corners (8pt), status dot (14pt) overlapping at bottom-right with white border
- **Line 1**: Customer name (17pt semibold) + Due date (15pt)
- **Line 2**: Service (+N counter) + Price (15pt)
- **Line 3**: Device info (13pt tertiary) + Indicators (overdue clock, paid dollar)
- **Config**: Added `showDeviceInOrderList` getter in `SegmentConfigProvider` for future per-segment customization

## Test plan
- [ ] Verify order list displays correctly with photos
- [ ] Verify placeholder icon matches segment (car for automotive, phone for smartphones, etc.)
- [ ] Verify status dot colors match order status
- [ ] Verify overdue indicator (red clock) appears for past due dates
- [ ] Verify paid indicator (green dollar) appears for paid orders
- [ ] Verify dark mode compatibility
- [ ] Verify tap feedback uses iOS native style

🤖 Generated with [Claude Code](https://claude.com/claude-code)