### PR TITLE
feat(ci): add automatic versioning with Conventional Commits

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -3,15 +3,37 @@ name: Release Android
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*-rc'  # Only trigger on RC tags
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v1.0.0-rc)'
+        required: false
+        type: string
 
 jobs:
   android:
     runs-on: ubuntu-latest
 
+    outputs:
+      version_name: ${{ steps.version.outputs.version_name }}
+      version_code: ${{ steps.version.outputs.version_code }}
+
     steps:
       - uses: actions/checkout@v4
+
+      # Extract version from tag
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.ref_name }}"
+          # Remove 'v' prefix and '-rc' suffix
+          VERSION="${TAG#v}"
+          VERSION="${VERSION%-rc}"
+
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version_name=$VERSION" >> $GITHUB_OUTPUT
+          echo "📦 Building version: $VERSION from tag: $TAG"
 
       # Setup Java
       - name: Setup Java
@@ -40,18 +62,6 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      # 🔍 Check for Metadata/Screenshot changes (only for production releases)
-      - name: Check for metadata changes
-        if: "!endsWith(github.ref, '-rc')"
-        uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            screenshots:
-              - 'android/fastlane/metadata/android/*/images/**'
-            metadata:
-              - 'android/fastlane/metadata/**'
-
       # 🔐 Restore Secrets
       
       - name: Make gradlew executable
@@ -72,25 +82,33 @@ jobs:
         run: |
           echo "${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > android/app/google-services.json
 
-      # 🚀 Build + Upload to Internal Track (apenas release candidate com -rc)
+      # 🚀 Build + Upload to Internal Track
       - name: Fastlane Internal (Google Play)
-        if: endsWith(github.ref, '-rc')
+        id: fastlane
         working-directory: android
         env:
           FASTLANE_SKIP_UPDATE_CHECK: "true"
           CI: "true"
         run: bundle exec fastlane internal
 
-      # 🚀 Build + Upload to Production (apenas tags v* sem -rc)
-      - name: Fastlane Release (Production)
-        if: "!endsWith(github.ref, '-rc')"
-        working-directory: android
+      # 📦 Upload AAB to GitHub Release
+      - name: Upload AAB to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Release ${{ steps.version.outputs.version_name }} (RC)"
+          draft: false
+          prerelease: true
+          files: |
+            build/app/outputs/bundle/release/app-release.aab
+          body: |
+            ## Android Release Candidate
+
+            **Version:** ${{ steps.version.outputs.version_name }}
+            **Tag:** ${{ github.ref_name }}
+
+            This is a release candidate deployed to Google Play Internal Track.
+
+            To promote to production, use the "Promote Release" workflow.
         env:
-          FASTLANE_SKIP_UPDATE_CHECK: "true"
-          CI: "true"
-        run: |
-          bundle exec fastlane deploy_with_metadata \
-            track:production \
-            skip_screenshots:${{ steps.filter.outputs.screenshots == 'false' }} \
-            skip_images:${{ steps.filter.outputs.screenshots == 'false' }} \
-            skip_metadata:${{ steps.filter.outputs.metadata == 'false' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -1,0 +1,158 @@
+name: Auto Version
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/auto-version.yml'
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    # Skip if commit is from this workflow (version bump commit)
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+    permissions:
+      contents: write
+
+    outputs:
+      new_tag: ${{ steps.version.outputs.new_tag }}
+      version: ${{ steps.version.outputs.version }}
+      bump_type: ${{ steps.analyze.outputs.bump_type }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get latest tag
+        id: latest_tag
+        run: |
+          # Get the latest version tag (ignore -rc suffix for base version)
+          LATEST_TAG=$(git tag -l 'v*' | grep -v '\-rc$' | sort -V | tail -1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            # If no production tag, check for RC tags
+            LATEST_TAG=$(git tag -l 'v*-rc' | sed 's/-rc$//' | sort -V | tail -1)
+            if [ -z "$LATEST_TAG" ]; then
+              LATEST_TAG="v0.0.0"
+            fi
+          fi
+
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "📌 Latest tag: $LATEST_TAG"
+
+      - name: Analyze commits (Conventional Commits)
+        id: analyze
+        run: |
+          LATEST_TAG="${{ steps.latest_tag.outputs.latest_tag }}"
+
+          # Get commits since last tag
+          if git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
+            COMMITS=$(git log "$LATEST_TAG"..HEAD --pretty=format:"%s" 2>/dev/null || echo "")
+          else
+            COMMITS=$(git log --pretty=format:"%s" -20)
+          fi
+
+          echo "📝 Commits since $LATEST_TAG:"
+          echo "$COMMITS"
+
+          # Analyze commit messages
+          BUMP_TYPE="patch"
+
+          if echo "$COMMITS" | grep -qiE "^feat(\(.+\))?!:|BREAKING CHANGE:"; then
+            BUMP_TYPE="major"
+          elif echo "$COMMITS" | grep -qiE "^feat(\(.+\))?:"; then
+            BUMP_TYPE="minor"
+          elif echo "$COMMITS" | grep -qiE "^fix(\(.+\))?:|^perf(\(.+\))?:|^refactor(\(.+\))?:"; then
+            BUMP_TYPE="patch"
+          fi
+
+          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+          echo "🔄 Bump type: $BUMP_TYPE"
+
+      - name: Calculate new version
+        id: version
+        run: |
+          LATEST_TAG="${{ steps.latest_tag.outputs.latest_tag }}"
+          BUMP_TYPE="${{ steps.analyze.outputs.bump_type }}"
+
+          # Remove 'v' prefix for parsing
+          VERSION="${LATEST_TAG#v}"
+
+          # Parse version components
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          MAJOR=${MAJOR:-0}
+          MINOR=${MINOR:-0}
+          PATCH=${PATCH:-0}
+
+          # Bump version based on type
+          case $BUMP_TYPE in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          NEW_TAG="v$NEW_VERSION-rc"
+
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+          echo "✅ New version: $NEW_VERSION (tag: $NEW_TAG)"
+
+      - name: Update pubspec.yaml
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+
+          # Read current build number and increment
+          CURRENT_BUILD=$(grep -E "^version:" pubspec.yaml | sed -E 's/.*\+([0-9]+)$/\1/')
+          NEW_BUILD=$((CURRENT_BUILD + 1))
+
+          # Update version in pubspec.yaml
+          sed -i "s/^version: .*/version: $NEW_VERSION+$NEW_BUILD/" pubspec.yaml
+
+          echo "📦 Updated pubspec.yaml to version: $NEW_VERSION+$NEW_BUILD"
+          grep "^version:" pubspec.yaml
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add pubspec.yaml
+          git commit -m "chore(release): bump version to ${{ steps.version.outputs.version }} [skip ci]"
+          git push origin master
+
+      - name: Create and push tag
+        run: |
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
+
+          git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+          git push origin "$NEW_TAG"
+
+          echo "🏷️ Created and pushed tag: $NEW_TAG"
+
+      - name: Summary
+        run: |
+          echo "## 🚀 Auto Version Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Previous Tag | ${{ steps.latest_tag.outputs.latest_tag }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Bump Type | ${{ steps.analyze.outputs.bump_type }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| New Version | ${{ steps.version.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| New Tag | ${{ steps.version.outputs.new_tag }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The release workflows will be triggered automatically by the new tag." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -3,8 +3,13 @@ name: Release iOS
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*-rc'  # Only trigger on RC tags
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v1.0.0-rc)'
+        required: false
+        type: string
 
 jobs:
   ios:
@@ -12,8 +17,24 @@ jobs:
     env:
       BUNDLE_ID: br.com.rafsoft.praticos
 
+    outputs:
+      version_name: ${{ steps.version.outputs.version_name }}
+
     steps:
       - uses: actions/checkout@v4
+
+      # Extract version from tag
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.ref_name }}"
+          # Remove 'v' prefix and '-rc' suffix
+          VERSION="${TAG#v}"
+          VERSION="${VERSION%-rc}"
+
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version_name=$VERSION" >> $GITHUB_OUTPUT
+          echo "📦 Building version: $VERSION from tag: $TAG"
 
       # Flutter SDK
       - name: Flutter
@@ -57,18 +78,6 @@ jobs:
         with:
           ruby-version: '3.2'
           bundler-cache: true
-
-      # 🔍 Check for Metadata/Screenshot changes (only for production releases)
-      - name: Check for metadata changes
-        if: "!endsWith(github.ref, '-rc')"
-        uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            screenshots:
-              - 'ios/fastlane/screenshots/**'
-            metadata:
-              - 'ios/fastlane/metadata/**'
 
       # 🔐 Importa o certificado .p12 no keychain
       - name: Import distribution cert
@@ -126,9 +135,8 @@ jobs:
           /usr/bin/plutil -lint GoogleService-Info.plist
           echo "GoogleService-Info.plist criado em ios/"
 
-      # 🚀 Build + upload para TestFlight (apenas release candidate com -rc)
+      # 🚀 Build + upload para TestFlight
       - name: Fastlane Beta (TestFlight)
-        if: endsWith(github.ref, '-rc')
         working-directory: ios
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -142,24 +150,42 @@ jobs:
           CI: "true"
         run: bundle exec fastlane beta
 
-      # 🚀 Build + upload para App Store (apenas tags v* sem -rc)
-      - name: Fastlane Release (App Store)
-        if: "!endsWith(github.ref, '-rc')"
-        working-directory: ios
-        env:
-          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_PRIVATE_KEY }}
-          BUNDLE_ID: ${{ env.BUNDLE_ID }}
-          DEVELOPMENT_TEAM: ${{ env.DEVELOPMENT_TEAM }}
-          PROFILE_UUID: ${{ env.PROFILE_UUID }}
-          PROFILE_NAME: ${{ env.PROFILE_NAME }}
-          FASTLANE_SKIP_UPDATE_CHECK: "true"
-          CI: "true"
+      # 📦 Find and rename IPA for upload
+      - name: Prepare IPA for upload
+        id: ipa
         run: |
-          bundle exec fastlane release_store \
-            skip_screenshots:${{ steps.filter.outputs.screenshots == 'false' }} \
-            skip_metadata:${{ steps.filter.outputs.metadata == 'false' }}
+          # Find the IPA file (Fastlane generates it in ios/ directory)
+          IPA_PATH=$(find ios -name "*.ipa" -type f | head -1)
+
+          if [ -z "$IPA_PATH" ]; then
+            echo "❌ No IPA file found!"
+            exit 1
+          fi
+
+          echo "Found IPA: $IPA_PATH"
+          echo "ipa_path=$IPA_PATH" >> $GITHUB_OUTPUT
+
+      # 📦 Upload IPA to GitHub Release
+      - name: Upload IPA to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Release ${{ steps.version.outputs.version_name }} (RC)"
+          draft: false
+          prerelease: true
+          files: |
+            ${{ steps.ipa.outputs.ipa_path }}
+          body: |
+            ## iOS Release Candidate
+
+            **Version:** ${{ steps.version.outputs.version_name }}
+            **Tag:** ${{ github.ref_name }}
+
+            This is a release candidate deployed to TestFlight.
+
+            To promote to production, use the "Promote Release" workflow.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload fastlane logs (on failure)
         if: failure()

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,284 @@
+name: Promote Release to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      rc_tag:
+        description: 'RC tag to promote (e.g., v1.0.3-rc)'
+        required: true
+        type: string
+      skip_android:
+        description: 'Skip Android promotion'
+        required: false
+        type: boolean
+        default: false
+      skip_ios:
+        description: 'Skip iOS promotion'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      rc_tag: ${{ steps.validate.outputs.rc_tag }}
+      prod_tag: ${{ steps.validate.outputs.prod_tag }}
+      version: ${{ steps.validate.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate RC tag
+        id: validate
+        run: |
+          RC_TAG="${{ inputs.rc_tag }}"
+
+          # Validate format
+          if [[ ! "$RC_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc$ ]]; then
+            echo "❌ Invalid tag format. Must be like v1.0.3-rc"
+            exit 1
+          fi
+
+          # Check if RC tag exists
+          if ! git rev-parse "$RC_TAG" >/dev/null 2>&1; then
+            echo "❌ Tag $RC_TAG not found"
+            exit 1
+          fi
+
+          # Calculate production tag
+          PROD_TAG="${RC_TAG%-rc}"
+          VERSION="${PROD_TAG#v}"
+
+          # Check if production tag already exists
+          if git rev-parse "$PROD_TAG" >/dev/null 2>&1; then
+            echo "❌ Production tag $PROD_TAG already exists"
+            exit 1
+          fi
+
+          echo "rc_tag=$RC_TAG" >> $GITHUB_OUTPUT
+          echo "prod_tag=$PROD_TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          echo "✅ Promoting $RC_TAG → $PROD_TAG"
+
+  promote-android:
+    needs: validate
+    if: ${{ !inputs.skip_android }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Check for Metadata/Screenshot changes since RC tag
+      - name: Check for metadata changes
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          base: ${{ needs.validate.outputs.rc_tag }}
+          filters: |
+            screenshots:
+              - 'android/fastlane/metadata/android/*/images/**'
+            metadata:
+              - 'android/fastlane/metadata/**'
+
+      - name: Log metadata status
+        run: |
+          echo "📸 Screenshots changed: ${{ steps.filter.outputs.screenshots }}"
+          echo "📝 Metadata changed: ${{ steps.filter.outputs.metadata }}"
+
+      # Download AAB from RC release
+      - name: Download AAB from RC release
+        run: |
+          mkdir -p artifacts
+          gh release download "${{ needs.validate.outputs.rc_tag }}" \
+            --pattern "*.aab" \
+            --dir ./artifacts
+
+          echo "📦 Downloaded artifacts:"
+          ls -la artifacts/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Setup Ruby + Bundler
+      - name: Ruby (bundler cache)
+        uses: ruby/setup-ruby@v1
+        env:
+          BUNDLE_GEMFILE: android/Gemfile
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      # Decode Play Store Credentials
+      - name: Decode Play Store Credentials
+        run: |
+          echo "${{ secrets.ANDROID_PLAY_STORE_CREDENTIALS_BASE64 }}" | base64 --decode > android/fastlane/play_store_credentials.json
+
+      # Upload to Production (no rebuild!)
+      - name: Upload to Production
+        working-directory: android
+        env:
+          FASTLANE_SKIP_UPDATE_CHECK: "true"
+          CI: "true"
+        run: |
+          bundle exec fastlane supply \
+            --aab ../artifacts/app-release.aab \
+            --track production \
+            --skip_upload_apk true \
+            --skip_upload_metadata ${{ steps.filter.outputs.metadata == 'false' }} \
+            --skip_upload_images ${{ steps.filter.outputs.screenshots == 'false' }} \
+            --skip_upload_screenshots ${{ steps.filter.outputs.screenshots == 'false' }}
+
+      - name: Summary
+        run: |
+          echo "✅ Android promoted to production!"
+          echo "   - Metadata uploaded: ${{ steps.filter.outputs.metadata }}"
+          echo "   - Screenshots uploaded: ${{ steps.filter.outputs.screenshots }}"
+
+  promote-ios:
+    needs: validate
+    if: ${{ !inputs.skip_ios }}
+    runs-on: macos-14
+    env:
+      BUNDLE_ID: br.com.rafsoft.praticos
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Check for Metadata/Screenshot changes since RC tag
+      - name: Check for metadata changes
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          base: ${{ needs.validate.outputs.rc_tag }}
+          filters: |
+            screenshots:
+              - 'ios/fastlane/screenshots/**'
+            metadata:
+              - 'ios/fastlane/metadata/**'
+
+      - name: Log metadata status
+        run: |
+          echo "📸 Screenshots changed: ${{ steps.filter.outputs.screenshots }}"
+          echo "📝 Metadata changed: ${{ steps.filter.outputs.metadata }}"
+
+      # Download IPA from RC release
+      - name: Download IPA from RC release
+        id: download
+        run: |
+          mkdir -p artifacts
+          gh release download "${{ needs.validate.outputs.rc_tag }}" \
+            --pattern "*.ipa" \
+            --dir ./artifacts
+
+          echo "📦 Downloaded artifacts:"
+          ls -la artifacts/
+
+          # Find the IPA file
+          IPA_PATH=$(find artifacts -name "*.ipa" -type f | head -1)
+          echo "ipa_path=$IPA_PATH" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Setup Ruby + Bundler
+      - name: Ruby (bundler cache)
+        uses: ruby/setup-ruby@v1
+        env:
+          BUNDLE_GEMFILE: ios/Gemfile
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      # Upload to App Store (no rebuild!)
+      - name: Upload to App Store
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_PRIVATE_KEY }}
+          FASTLANE_SKIP_UPDATE_CHECK: "true"
+          CI: "true"
+        run: |
+          IPA_PATH="${{ steps.download.outputs.ipa_path }}"
+          bundle exec fastlane deliver \
+            --ipa "../$IPA_PATH" \
+            --skip_screenshots ${{ steps.filter.outputs.screenshots == 'false' }} \
+            --skip_metadata ${{ steps.filter.outputs.metadata == 'false' }} \
+            --force true \
+            --submit_for_review false \
+            --run_precheck_before_submit false
+
+      - name: Summary
+        run: |
+          echo "✅ iOS promoted to App Store!"
+          echo "   - Metadata uploaded: ${{ steps.filter.outputs.metadata }}"
+          echo "   - Screenshots uploaded: ${{ steps.filter.outputs.screenshots }}"
+
+  create-production-tag:
+    needs: [validate, promote-android, promote-ios]
+    # Run even if one platform was skipped
+    if: always() && needs.validate.result == 'success' && (needs.promote-android.result == 'success' || needs.promote-android.result == 'skipped') && (needs.promote-ios.result == 'success' || needs.promote-ios.result == 'skipped')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create production tag
+        run: |
+          RC_TAG="${{ needs.validate.outputs.rc_tag }}"
+          PROD_TAG="${{ needs.validate.outputs.prod_tag }}"
+
+          # Get the commit from RC tag
+          COMMIT=$(git rev-list -n 1 "$RC_TAG")
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create production tag pointing to the same commit
+          git tag -a "$PROD_TAG" "$COMMIT" -m "Production release $PROD_TAG (promoted from $RC_TAG)"
+          git push origin "$PROD_TAG"
+
+          echo "🏷️ Created production tag: $PROD_TAG"
+
+      - name: Update GitHub Release
+        run: |
+          PROD_TAG="${{ needs.validate.outputs.prod_tag }}"
+          RC_TAG="${{ needs.validate.outputs.rc_tag }}"
+          VERSION="${{ needs.validate.outputs.version }}"
+
+          # Update the RC release to be the production release
+          gh release edit "$RC_TAG" \
+            --title "Release $VERSION" \
+            --prerelease=false \
+            --notes "## Production Release
+
+          **Version:** $VERSION
+          **Promoted from:** $RC_TAG
+
+          This release has been promoted to production on both Google Play and App Store."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## 🚀 Promotion Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| RC Tag | ${{ needs.validate.outputs.rc_tag }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Production Tag | ${{ needs.validate.outputs.prod_tag }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Version | ${{ needs.validate.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The same binaries that were tested in RC are now in production!" >> $GITHUB_STEP_SUMMARY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,14 +342,95 @@ intl: ^0.20.2
 ## Dicas para Agentes de IA
 
 1. **🚨 INGLÊS NO CÓDIGO (CRÍTICO):** TODO código, tipos, constantes, enums, propriedades, métodos, chaves JSON e valores no banco DEVEM ser em inglês. Português apenas para UI strings visíveis ao usuário.
-2. **Multi-Tenancy é Prioridade:** Verifique sempre se está usando a estrutura correta de company/roles.
-3. **UX/UI Guidelines:**
+2. **🏷️ CONVENTIONAL COMMITS (OBRIGATÓRIO):** Usar formato padronizado para commits. Ver seção abaixo.
+3. **Multi-Tenancy é Prioridade:** Verifique sempre se está usando a estrutura correta de company/roles.
+4. **UX/UI Guidelines:**
     - **App:** Cupertino/iOS-first. Siga `@docs/UX_GUIDELINES.md`.
     - **Web:** Dark Premium Theme. Siga `@docs/WEB_UX_GUIDELINES.md`.
-4. **Build Runner:** `fvm flutter pub run build_runner build --delete-conflicting-outputs` é obrigatório após mudar Stores/Models.
-5. **AuthService:** Use `AuthService` para criar novos usuários, não grave direto no banco.
-6. **CollaboratorStore:** Use este store para gerenciar membros da equipe, não use `CompanyStore` para isso.
-7. **📝 DOCUMENTAÇÃO OBRIGATÓRIA:** Ao finalizar uma nova feature, SEMPRE documentar (ver seção abaixo).
+5. **Build Runner:** `fvm flutter pub run build_runner build --delete-conflicting-outputs` é obrigatório após mudar Stores/Models.
+6. **AuthService:** Use `AuthService` para criar novos usuários, não grave direto no banco.
+7. **CollaboratorStore:** Use este store para gerenciar membros da equipe, não use `CompanyStore` para isso.
+8. **📝 DOCUMENTAÇÃO OBRIGATÓRIA:** Ao finalizar uma nova feature, SEMPRE documentar (ver seção abaixo).
+
+---
+
+## Conventional Commits (Versionamento Automático)
+
+O projeto usa versionamento automático baseado em Conventional Commits. **Todo commit deve seguir o formato:**
+
+```
+<type>(<scope>): <description>
+```
+
+### Tipos de Commit e Versão Gerada
+
+| Tipo | Descrição | Versão |
+|------|-----------|--------|
+| `feat` | Nova funcionalidade | **Minor** (1.0.0 → 1.1.0) |
+| `feat!` | Feature com breaking change | **Major** (1.0.0 → 2.0.0) |
+| `fix` | Correção de bug | **Patch** (1.0.0 → 1.0.1) |
+| `perf` | Melhoria de performance | Patch |
+| `refactor` | Refatoração de código | Patch |
+| `docs` | Documentação | Patch |
+| `style` | Formatação de código | Patch |
+| `test` | Testes | Patch |
+| `chore` | Manutenção | Patch |
+| `ci` | CI/CD | Patch |
+| `build` | Build system | Patch |
+
+### Scopes Comuns
+
+- `auth` - Autenticação
+- `orders` - Ordens de serviço
+- `customers` - Clientes
+- `ui` - Interface do usuário
+- `storage` - Firebase Storage
+- `db` - Firestore
+
+### Exemplos
+
+```bash
+# ✅ CORRETO
+
+# Feature (gera Minor bump)
+git commit -m "feat: add dark mode toggle"
+git commit -m "feat(orders): add bulk status update"
+
+# Fix (gera Patch bump)
+git commit -m "fix: resolve crash on login"
+git commit -m "fix(auth): handle expired token gracefully"
+
+# Breaking change (gera Major bump)
+git commit -m "feat!: new authentication system"
+git commit -m "feat: new order flow
+
+BREAKING CHANGE: removed 'pending_payment' status"
+
+# Outros (geram Patch bump)
+git commit -m "refactor(ui): reorganize widget structure"
+git commit -m "perf: lazy load order images"
+git commit -m "chore: update dependencies"
+git commit -m "docs: update API documentation"
+git commit -m "test: add unit tests for Order"
+
+# ❌ ERRADO
+
+git commit -m "add dark mode"           # Falta tipo
+git commit -m "FEAT: add dark mode"     # Maiúsculo
+git commit -m "feat - add dark mode"    # Formato errado
+git commit -m "feat: added dark mode"   # Tempo verbal errado (usar imperativo)
+git commit -m "feature: add dark mode"  # Tipo não reconhecido
+```
+
+### Regras de Prioridade
+
+Quando múltiplos commits são analisados, o bump de maior prioridade vence:
+
+1. **Major** - Qualquer commit com `!` ou `BREAKING CHANGE`
+2. **Minor** - Qualquer commit `feat`
+3. **Patch** - Todos os outros tipos reconhecidos
+
+Ver `docs/AUTO_VERSIONING.md` para documentação completa.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,35 +261,96 @@ Sistema de checklists e vistorias personalizados.
 
 ## Deploy
 
-### Android (Play Store)
+### Versionamento Automático (Conventional Commits)
+
+O projeto usa versionamento automático baseado em Conventional Commits.
+
+**Formato:** `<type>(<scope>): <description>`
+
+| Tipo | Descrição | Versão |
+|------|-----------|--------|
+| `feat` | Nova funcionalidade | Minor (1.0.0 → 1.1.0) |
+| `feat!` | Feature com breaking change | Major (1.0.0 → 2.0.0) |
+| `fix` | Correção de bug | Patch (1.0.0 → 1.0.1) |
+| `perf` | Melhoria de performance | Patch |
+| `refactor` | Refatoração de código | Patch |
+| `docs` | Documentação | Patch |
+| `style` | Formatação de código | Patch |
+| `test` | Testes | Patch |
+| `chore` | Manutenção | Patch |
+| `ci` | CI/CD | Patch |
+| `build` | Build system | Patch |
+
+**Exemplos:**
 ```bash
-cd android
-bundle exec fastlane internal           # Internal track
-bundle exec fastlane deploy_with_metadata  # Com metadados
-bundle exec fastlane promote_to_production
+# Feature (Minor)
+git commit -m "feat: add dark mode toggle"
+git commit -m "feat(orders): add bulk status update"
+
+# Fix (Patch)
+git commit -m "fix: resolve crash on login"
+git commit -m "fix(auth): handle expired token"
+
+# Breaking change (Major) - usar ! ou BREAKING CHANGE
+git commit -m "feat!: new authentication flow"
+git commit -m "feat: new API
+
+BREAKING CHANGE: removed v1 endpoints"
+
+# Outros (Patch)
+git commit -m "refactor(ui): reorganize widgets"
+git commit -m "perf: optimize image loading"
+git commit -m "chore: update dependencies"
 ```
 
-### iOS (App Store)
+**Scopes comuns:** `auth`, `orders`, `customers`, `ui`, `storage`, `db`
+
+Ver `docs/AUTO_VERSIONING.md` para detalhes completos.
+
+### Fluxo de Release
+
+```
+PR mergeado na master
+        ↓
+auto-version.yml → cria tag v*-rc
+        ↓
+Build + Upload para TestFlight/Internal
+        ↓
+Artefatos salvos no GitHub Releases
+        ↓
+[Após testes] Workflow "Promote Release"
+        ↓
+Mesmo binário vai para produção
+```
+
+### Comandos Locais (quando necessário)
+
 ```bash
+# Android
+cd android
+bundle exec fastlane internal           # Internal track (manual)
+
+# iOS
 cd ios
-bundle exec fastlane beta               # TestFlight
-bundle exec fastlane release_store      # App Store
+bundle exec fastlane beta               # TestFlight (manual)
 ```
 
 ### CI/CD
-- **Push master**: Deploy para trilhas internas (Internal/TestFlight)
-- **Tag `v*`**: Deploy para produção
+- **Push master**: Cria tag `-rc` automaticamente, deploy para teste
+- **Promote Release**: Workflow manual para promover RC para produção
+- **Artefatos**: Salvos no GitHub Releases (AAB + IPA)
 
 ## Regras Importantes
 
 1. **Inglês no Código**: SEMPRE usar inglês para classes, variáveis, constantes, enums, chaves JSON e valores no banco
-2. **Multi-Tenancy é Prioridade**: Sempre verificar estrutura de company/roles
-3. **Build Runner**: Executar após alterar Stores/Models
-4. **AuthService**: Usar para criar novos usuários (não gravar direto no banco)
-5. **CollaboratorStore**: Usar para gerenciar membros da equipe (não usar CompanyStore)
-6. **Cupertino-first**: App deve parecer nativo iOS
-7. **Dark Mode**: Sempre usar `.resolveFrom(context)` para cores dinâmicas
-8. **Documentação Obrigatória**: Documentar toda nova funcionalidade (ver seção abaixo)
+2. **Conventional Commits**: Usar formato `tipo: descrição` para commits (feat, fix, refactor, etc.)
+3. **Multi-Tenancy é Prioridade**: Sempre verificar estrutura de company/roles
+4. **Build Runner**: Executar após alterar Stores/Models
+5. **AuthService**: Usar para criar novos usuários (não gravar direto no banco)
+6. **CollaboratorStore**: Usar para gerenciar membros da equipe (não usar CompanyStore)
+7. **Cupertino-first**: App deve parecer nativo iOS
+8. **Dark Mode**: Sempre usar `.resolveFrom(context)` para cores dinâmicas
+9. **Documentação Obrigatória**: Documentar toda nova funcionalidade (ver seção abaixo)
 
 ---
 
@@ -385,6 +446,7 @@ Antes de finalizar uma feature, verificar:
 
 ## Documentação Adicional
 
+- `docs/AUTO_VERSIONING.md` - Versionamento automático e Conventional Commits
 - `docs/UX_GUIDELINES.md` - Padrões visuais iOS/Cupertino
 - `docs/WEB_UX_GUIDELINES.md` - Padrões para site institucional
 - `docs/MULTI_TENANCY.md` - Detalhes da arquitetura multi-tenant

--- a/docs/AUTO_VERSIONING.md
+++ b/docs/AUTO_VERSIONING.md
@@ -1,0 +1,367 @@
+# Auto Versioning
+
+## Overview
+
+Automatic versioning system based on Conventional Commits that manages version bumps, tag creation, and artifact promotion for the PraticOS mobile app.
+
+## Architecture
+
+### Workflows
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         auto-version.yml                         │
+│  Trigger: push to master                                         │
+│  Actions: Analyze commits → Bump version → Update pubspec.yaml   │
+│           → Create v*-rc tag                                     │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│            android_release.yml + ios_release.yml                 │
+│  Trigger: v*-rc tag                                              │
+│  Actions: Build → Upload to Internal/TestFlight                  │
+│           → Save artifacts to GitHub Release                     │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      promote-release.yml                         │
+│  Trigger: workflow_dispatch (manual)                             │
+│  Actions: Download artifacts → Upload to Production              │
+│           → Create production tag                                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/auto-version.yml` | Analyzes commits, bumps version, creates RC tag |
+| `.github/workflows/android_release.yml` | Builds Android, uploads to Internal, saves AAB |
+| `.github/workflows/ios_release.yml` | Builds iOS, uploads to TestFlight, saves IPA |
+| `.github/workflows/promote-release.yml` | Promotes RC to production using saved artifacts |
+
+## Conventional Commits
+
+The system analyzes commit messages to determine version bump type automatically.
+
+### Commit Message Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Required format:**
+- `type`: Required. One of the types listed below
+- `scope`: Optional. Module/area affected (e.g., `auth`, `orders`, `ui`)
+- `description`: Required. Short description in imperative mood
+- `!` after type/scope: Indicates breaking change
+
+### Commit Types and Version Bumps
+
+| Type | Description | Version Bump | Example |
+|------|-------------|--------------|---------|
+| `feat` | New feature or functionality | **Minor** (1.0.0 → 1.1.0) | `feat: add dark mode toggle` |
+| `feat!` | New feature with breaking change | **Major** (1.0.0 → 2.0.0) | `feat!: new auth system` |
+| `fix` | Bug fix | **Patch** (1.0.0 → 1.0.1) | `fix: resolve login crash` |
+| `perf` | Performance improvement | **Patch** | `perf: optimize image loading` |
+| `refactor` | Code refactoring (no feature/fix) | **Patch** | `refactor: restructure auth module` |
+| `docs` | Documentation only | **Patch** | `docs: update API guide` |
+| `style` | Code style (formatting, semicolons) | **Patch** | `style: fix indentation` |
+| `test` | Adding or updating tests | **Patch** | `test: add unit tests for Order` |
+| `chore` | Maintenance tasks | **Patch** | `chore: update dependencies` |
+| `ci` | CI/CD configuration | **Patch** | `ci: add caching to workflow` |
+| `build` | Build system changes | **Patch** | `build: update gradle config` |
+
+### Breaking Changes (Major Bump)
+
+Two ways to indicate a breaking change:
+
+**Option 1: Exclamation mark after type**
+```bash
+feat!: new authentication flow
+fix!: change API response format
+refactor!: rename public methods
+```
+
+**Option 2: BREAKING CHANGE footer**
+```bash
+feat: new API endpoints
+
+BREAKING CHANGE: removed v1 endpoints, use v2 instead
+```
+
+### Scope (Optional)
+
+The scope provides context about which module is affected:
+
+```bash
+feat(auth): add biometric login
+fix(orders): resolve date picker crash
+refactor(ui): reorganize widget structure
+perf(storage): optimize image upload
+```
+
+Common scopes for PraticOS:
+- `auth` - Authentication
+- `orders` - Order management
+- `customers` - Customer module
+- `ui` - User interface
+- `storage` - Firebase Storage
+- `db` - Firestore database
+
+### Complete Examples
+
+```bash
+# Feature (Minor bump: 1.0.0 → 1.1.0)
+git commit -m "feat: add customer export to PDF"
+git commit -m "feat(orders): add bulk status update"
+
+# Fix (Patch bump: 1.0.0 → 1.0.1)
+git commit -m "fix: resolve crash when email is empty"
+git commit -m "fix(auth): handle expired token gracefully"
+
+# Performance (Patch bump)
+git commit -m "perf: lazy load order images"
+git commit -m "perf(storage): compress images before upload"
+
+# Refactor (Patch bump)
+git commit -m "refactor: extract validation logic to service"
+git commit -m "refactor(models): simplify Order serialization"
+
+# Breaking change (Major bump: 1.0.0 → 2.0.0)
+git commit -m "feat!: new authentication system"
+
+# Breaking change with body
+git commit -m "feat: new order status flow
+
+BREAKING CHANGE: removed 'pending_payment' status, use 'awaiting_payment' instead"
+
+# Chore (Patch bump)
+git commit -m "chore: update Flutter to 3.32"
+git commit -m "chore(deps): bump firebase_core to 3.14"
+
+# Docs (Patch bump)
+git commit -m "docs: add API documentation"
+git commit -m "docs(readme): update installation steps"
+
+# CI (Patch bump)
+git commit -m "ci: add iOS build caching"
+git commit -m "ci(release): optimize artifact upload"
+```
+
+### What NOT to do
+
+```bash
+# ❌ Missing type
+git commit -m "add dark mode"
+
+# ❌ Wrong format (uppercase, no colon)
+git commit -m "FEAT add dark mode"
+git commit -m "feat - add dark mode"
+
+# ❌ Past tense (use imperative)
+git commit -m "feat: added dark mode"
+
+# ❌ Type not recognized
+git commit -m "feature: add dark mode"
+git commit -m "bugfix: resolve crash"
+
+# ✅ Correct
+git commit -m "feat: add dark mode"
+git commit -m "fix: resolve crash"
+```
+
+### Priority Rules
+
+When multiple commits are analyzed, the highest priority bump wins:
+
+1. **Major** - Any commit with `!` or `BREAKING CHANGE`
+2. **Minor** - Any `feat` commit
+3. **Patch** - All other recognized types
+
+## Data Flow
+
+### 1. Development Phase
+
+```
+Developer creates PR
+         │
+         ▼
+PR merged to master
+         │
+         ▼
+auto-version.yml triggers
+         │
+         ├─► Analyzes commits since last tag
+         │
+         ├─► Determines bump type (major/minor/patch)
+         │
+         ├─► Updates pubspec.yaml (version + build number)
+         │
+         ├─► Commits: "chore(release): bump version to X.Y.Z [skip ci]"
+         │
+         └─► Creates and pushes tag: vX.Y.Z-rc
+```
+
+### 2. Build Phase
+
+```
+v*-rc tag pushed
+         │
+         ├─► android_release.yml
+         │        │
+         │        ├─► Builds AAB
+         │        ├─► Uploads to Google Play Internal
+         │        └─► Saves AAB to GitHub Release
+         │
+         └─► ios_release.yml
+                  │
+                  ├─► Builds IPA
+                  ├─► Uploads to TestFlight
+                  └─► Saves IPA to GitHub Release
+```
+
+### 3. Testing Phase
+
+```
+QA tests the app from TestFlight/Internal
+         │
+         ▼
+    [Tests OK?]
+         │
+    ┌────┴────┐
+    │         │
+   Yes        No
+    │         │
+    ▼         ▼
+Promote    Fix bugs
+    │      (new PR)
+    ▼
+promote-release.yml
+```
+
+### 4. Promotion Phase
+
+```
+Developer triggers promote-release.yml
+         │
+         ├─► Input: v1.0.3-rc
+         │
+         ├─► Downloads AAB from GitHub Release
+         │
+         ├─► Downloads IPA from GitHub Release
+         │
+         ├─► Uploads AAB to Google Play Production
+         │
+         ├─► Uploads IPA to App Store
+         │
+         ├─► Creates production tag: v1.0.3
+         │
+         └─► Updates GitHub Release (marks as production)
+```
+
+## Business Rules
+
+1. **Version Source of Truth**: `pubspec.yaml` is always in sync with the latest tag
+2. **Build Numbers**: Automatically incremented with each release
+3. **RC Tags**: All automated releases are RC (`-rc` suffix)
+4. **Production Tags**: Only created via manual promotion
+5. **Same Binary**: Production uses the exact same binary that was tested
+6. **No Rebuild**: Promotion downloads pre-built artifacts, never rebuilds
+
+## Version Format
+
+```
+version: X.Y.Z+BUILD
+
+Where:
+- X = Major (breaking changes)
+- Y = Minor (new features)
+- Z = Patch (bug fixes)
+- BUILD = Incremental build number
+```
+
+**Example:** `1.2.3+45` means version 1.2.3, build number 45.
+
+## GitHub Releases
+
+Each RC creates a GitHub Release with:
+- Tag: `v1.0.3-rc`
+- Title: "Release 1.0.3 (RC)"
+- Prerelease: true
+- Artifacts:
+  - `app-release.aab` (Android)
+  - `Runner.ipa` (iOS)
+
+After promotion:
+- Tag: `v1.0.3` (additional tag, same commit)
+- Title: "Release 1.0.3"
+- Prerelease: false
+
+## Usage Examples
+
+### Normal Development Flow
+
+```bash
+# Work on feature
+git checkout -b feature/dark-mode
+# ... make changes ...
+git commit -m "feat: add dark mode toggle"
+git push origin feature/dark-mode
+
+# Create PR, get reviews, merge to master
+# → auto-version.yml creates v1.1.0-rc
+# → Builds go to TestFlight/Internal
+
+# After testing, promote via GitHub Actions UI
+# → promote-release.yml with input "v1.1.0-rc"
+# → Same binaries go to production
+```
+
+### Bug Fix Flow
+
+```bash
+git checkout -b fix/login-crash
+git commit -m "fix: resolve crash when email is empty"
+git push origin fix/login-crash
+
+# Merge to master
+# → auto-version.yml creates v1.1.1-rc (patch bump)
+```
+
+### Breaking Change
+
+```bash
+git commit -m "feat!: new authentication system
+
+BREAKING CHANGE: removed password-only login"
+
+# → auto-version.yml creates v2.0.0-rc (major bump)
+```
+
+## Troubleshooting
+
+### Version not bumping correctly
+
+1. Check commit message format (must follow Conventional Commits)
+2. Verify commits are since the last tag
+3. Check workflow logs for commit analysis output
+
+### Promotion fails
+
+1. Verify RC tag exists
+2. Check GitHub Release has artifacts
+3. Verify production tag doesn't already exist
+4. Check store credentials are valid
+
+### Build number conflicts
+
+The Fastlane scripts automatically fetch the latest build number from stores and increment. If conflicts occur:
+1. Check both Internal and Production tracks
+2. Manually increment if needed via `--build-number` flag


### PR DESCRIPTION
## Summary

- Add automatic versioning system based on Conventional Commits
- Implement artifact promotion workflow (build once, deploy many)
- Update release workflows to save artifacts to GitHub Releases
- Add comprehensive documentation for the new versioning flow

## New Workflows

| Workflow | Trigger | Purpose |
|----------|---------|---------|
| `auto-version.yml` | Push to master | Analyzes commits, bumps version, creates `-rc` tag |
| `promote-release.yml` | Manual | Promotes RC to production using saved artifacts |

## Modified Workflows

| Workflow | Changes |
|----------|---------|
| `android_release.yml` | Triggers on `v*-rc`, saves AAB to GitHub Releases |
| `ios_release.yml` | Triggers on `v*-rc`, saves IPA to GitHub Releases |

## New Release Flow

```
PR merged to master
       ↓
auto-version.yml
├── Analyzes commits (feat→minor, fix→patch, feat!→major)
├── Updates pubspec.yaml
└── Creates tag v1.0.3-rc
       ↓
android_release.yml + ios_release.yml
├── Build AAB/IPA
├── Upload to Internal/TestFlight
└── Save artifacts to GitHub Releases
       ↓
[Testing OK]
       ↓
promote-release.yml (manual)
├── Download artifacts from GitHub Releases
├── Upload to Production (no rebuild!)
├── Upload metadata/screenshots if changed
└── Create production tag v1.0.3
```

## Conventional Commits

| Type | Version Bump |
|------|--------------|
| `feat` | Minor (1.0.0 → 1.1.0) |
| `feat!` / `BREAKING CHANGE` | Major (1.0.0 → 2.0.0) |
| `fix`, `perf`, `refactor`, `docs`, `chore`, etc. | Patch (1.0.0 → 1.0.1) |

## Test plan

- [ ] Merge this PR to master
- [ ] Verify `auto-version.yml` triggers and creates RC tag
- [ ] Verify `android_release.yml` and `ios_release.yml` build and save artifacts
- [ ] Verify artifacts appear in GitHub Releases
- [ ] Run `promote-release.yml` manually with the RC tag
- [ ] Verify production upload works without rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)