### PR TITLE
fix(ios): reduce App Store keywords length below 100 characters limit

### DIFF
--- a/ios/fastlane/metadata/en-US/keywords.txt
+++ b/ios/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-service order,work order,management,customers,repair shop,technical service,quote,services,control,business
+service order,work order,management,customers,repair shop,technical service,quote,services

--- a/ios/fastlane/metadata/es-ES/keywords.txt
+++ b/ios/fastlane/metadata/es-ES/keywords.txt
@@ -1,1 +1,1 @@
-orden de servicio,gestión,clientes,taller,servicio técnico,presupuesto,servicios,control,negocio,reparación
+orden de servicio,gestión,clientes,taller,servicio técnico,presupuesto,servicios,reparación

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -802,6 +802,24 @@ abstract class AppLocalizations {
   /// **'Nenhum dado disponível'**
   String get noData;
 
+  /// No description provided for @noValuesRegistered.
+  ///
+  /// In pt, this message translates to:
+  /// **'Nenhum valor cadastrado'**
+  String get noValuesRegistered;
+
+  /// No description provided for @typeAboveToAdd.
+  ///
+  /// In pt, this message translates to:
+  /// **'Digite no campo acima para adicionar'**
+  String get typeAboveToAdd;
+
+  /// No description provided for @addNewValue.
+  ///
+  /// In pt, this message translates to:
+  /// **'Adicionar novo valor'**
+  String get addNewValue;
+
   /// No description provided for @selectAtLeastOne.
   ///
   /// In pt, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -362,6 +362,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noData => 'No data available';
 
   @override
+  String get noValuesRegistered => 'No values registered';
+
+  @override
+  String get typeAboveToAdd => 'Type above to add';
+
+  @override
+  String get addNewValue => 'Add new value';
+
+  @override
   String get selectAtLeastOne => 'Select at least one option';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -363,6 +363,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noData => 'No hay datos disponibles';
 
   @override
+  String get noValuesRegistered => 'No hay valores registrados';
+
+  @override
+  String get typeAboveToAdd => 'Escriba arriba para agregar';
+
+  @override
+  String get addNewValue => 'Agregar nuevo valor';
+
+  @override
   String get selectAtLeastOne => 'Seleccione al menos una opción';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -364,6 +364,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noData => 'Nenhum dado disponível';
 
   @override
+  String get noValuesRegistered => 'Nenhum valor cadastrado';
+
+  @override
+  String get typeAboveToAdd => 'Digite no campo acima para adicionar';
+
+  @override
+  String get addNewValue => 'Adicionar novo valor';
+
+  @override
   String get selectAtLeastOne => 'Selecione ao menos uma opção';
 
   @override


### PR DESCRIPTION
## Descrição

Corrige o erro de validação da App Store onde as keywords excediam o limite de 100 caracteres.

## Mudanças

- Reduzidas keywords para **en-US** de 108 para 91 caracteres
- Reduzidas keywords para **es-ES** de 111 para 95 caracteres
- Removidas palavras menos essenciais (control, business, negocio) para manter dentro do limite

## Arquivos Alterados

- `ios/fastlane/metadata/en-US/keywords.txt`
- `ios/fastlane/metadata/es-ES/keywords.txt`
- Arquivos de localização atualizados

## Testes

✅ Keywords agora estão abaixo do limite de 100 caracteres
✅ Formato mantém as palavras-chave mais relevantes

## Tipo de Release

**Patch** - Correção de bug que não afeta funcionalidade do app