### PR TITLE
fix(ui): fix item deletion in accumulated values list

### DIFF
--- a/lib/screens/accumulated_value_list_screen.dart
+++ b/lib/screens/accumulated_value_list_screen.dart
@@ -445,7 +445,7 @@ class _AccumulatedValueListScreenState
             ),
           ),
           confirmDismiss: (direction) async {
-            return await showCupertinoDialog<bool>(
+            final confirmed = await showCupertinoDialog<bool>(
               context: context,
               builder: (context) => CupertinoAlertDialog(
                 title: Text(context.l10n.delete),
@@ -464,17 +464,27 @@ class _AccumulatedValueListScreenState
                 ],
               ),
             );
-          },
-          onDismissed: (direction) async {
-            if (value.id != null) {
+
+            if (confirmed == true && value.id != null) {
               try {
                 await _repo.remove(_companyId!, _fieldType!, value.id!);
                 debugPrint('AccumulatedValueListScreen: Deleted value: ${value.value}');
-                await _loadValues();
+                // Remove from local list to prevent item from reappearing
+                setState(() {
+                  _allValues.removeWhere((v) => v.id == value.id);
+                  _filteredValues.removeWhere((v) => v.id == value.id);
+                });
+                return true;
               } catch (e) {
                 debugPrint('Error deleting accumulated value: $e');
+                return false;
               }
             }
+            return false;
+          },
+          onDismissed: (direction) {
+            // Deletion already handled in confirmDismiss
+            debugPrint('AccumulatedValueListScreen: Item dismissed from UI');
           },
           child: CupertinoButton(
             padding: EdgeInsets.zero,


### PR DESCRIPTION
Move Firestore deletion from onDismissed to confirmDismiss callback. The previous implementation had a race condition where the Dismissible widget didn't wait for the async deletion, causing items to reappear when the list was rebuilt before the deletion completed.

Now the deletion happens inside confirmDismiss and only returns true after successful deletion, ensuring proper synchronization.