### PR TITLE
fix(invites): resolve race condition when loading pending invites

### DIFF
--- a/lib/mobx/invite_store.dart
+++ b/lib/mobx/invite_store.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:mobx/mobx.dart';
 import 'package:praticos/global.dart';
 import 'package:praticos/models/invite.dart';
@@ -39,7 +40,9 @@ abstract class _InviteStore with Store {
   /// Carrega os convites pendentes para o email do usuário atual.
   @action
   Future<void> loadPendingInvites() async {
-    final email = Global.currentUser?.email;
+    // Usa FirebaseAuth diretamente para evitar race condition com Global.currentUser
+    // que é definido assincronamente após o login
+    final email = FirebaseAuth.instance.currentUser?.email;
     if (email == null) return;
 
     isLoading = true;


### PR DESCRIPTION
The loadPendingInvites() method was using Global.currentUser?.email which is set asynchronously after login. For new users, this caused a race condition where the PendingInvitesScreen would call loadPendingInvites() before Global.currentUser was populated, resulting in no invites being displayed even when pending invites existed.

Now uses FirebaseAuth.instance.currentUser?.email directly, which is available immediately after authentication, matching the behavior already used in AuthWrapper._checkPendingInvites().