### PR TITLE
fix(fastlane): always submit for review after iOS promote

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -236,8 +236,6 @@ platform :ios do
     # Use existing TestFlight build - no binary upload needed
     # Always upload metadata when promoting to App Store
     # reject_if_possible: cancels any pending "Waiting for Review" submission
-    # IMPORTANT: When uploading screenshots, DO NOT submit_for_review immediately
-    # App Store Connect needs time to process screenshots before submission
     upload_to_app_store(
       app_version: app_version,  # Version to create/use in App Store
       skip_binary_upload: true,  # Use build already in TestFlight
@@ -247,19 +245,13 @@ platform :ios do
       overwrite_screenshots: true,  # Replace existing screenshots instead of adding
       ignore_language_directory_validation: true,  # Allow flexible directory structure
       screenshots_path: "./fastlane/screenshots",  # Explicit path to screenshots
-      submit_for_review: skip_screenshots,  # Only auto-submit if NO screenshots uploaded
+      submit_for_review: true,  # Always submit for review after upload
       reject_if_possible: true,  # Cancel pending review before submitting new one
       run_precheck_before_submit: false,
       precheck_default_rule_level: :skip  # Skip precheck validations that might fail with API key
     )
 
-    if skip_screenshots
-      UI.success("✅ TestFlight build submitted for App Store review!")
-    else
-      UI.important("📸 Screenshots uploaded. App Store Connect is processing them.")
-      UI.important("⏳ Please wait 5-10 minutes for processing to complete.")
-      UI.important("🔄 Then manually submit for review in App Store Connect or run this workflow again with skip_screenshots:true")
-    end
+    UI.success("✅ App submitted for App Store review!")
   end
 
   desc "Clear all screenshots from App Store Connect (useful before fresh upload)"


### PR DESCRIPTION
## Summary

- Always submit for App Store review after promote, regardless of screenshot upload

## Changes

- Changed `submit_for_review: skip_screenshots` to `submit_for_review: true`
- Simplified success message

## Behavior

Before: Only submitted for review when NOT uploading screenshots
After: Always submits for review after metadata/screenshots upload

## Test plan

- [x] Verify Fastfile syntax is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)