### PR TITLE
feat(ui): improve order number badge with status color

### DIFF
--- a/lib/screens/menu_navigation/home.dart
+++ b/lib/screens/menu_navigation/home.dart
@@ -800,17 +800,61 @@ class _HomeState extends State<Home> {
                     ),
                   ],
                 ),
-                child: Text(
-                  '#${order.number}',
-                  style: const TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w700,
-                    color: CupertinoColors.white,
-                  ),
-                ),
+                child: _buildOrderNumberText(order.number!),
               ),
             ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildOrderNumberText(int number) {
+    final numberStr = number.toString();
+
+    // Se tem 4 ou mais dígitos, mostra # e os primeiros menores e os últimos 3 maiores
+    if (numberStr.length > 3) {
+      final prefix = '${numberStr.substring(0, numberStr.length - 3)}.';
+      final suffix = numberStr.substring(numberStr.length - 3);
+
+      return Text.rich(
+        TextSpan(
+          children: [
+            const TextSpan(
+              text: '',
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w600,
+                color: CupertinoColors.white,
+              ),
+            ),
+            TextSpan(
+              text: prefix,
+              style: const TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w600,
+                color: CupertinoColors.white,
+              ),
+            ),
+            TextSpan(
+              text: suffix,
+              style: const TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+                color: CupertinoColors.white,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    // Se tem 3 ou menos dígitos, mostra normal com #
+    return Text(
+      '#$numberStr',
+      style: const TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w700,
+        color: CupertinoColors.white,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Use status color as badge background (blue=approved, green=done, etc.)
- Remove separate status dot - unified in single badge
- Smart formatting for large order numbers (4+ digits):
  - First digits shown smaller with dot separator
  - Last 3 digits shown larger for quick identification
  - Example: `12345` → `12.345` with size variation

## Test plan
- [ ] Open the orders list (Home screen)
- [ ] Verify badge color matches order status
- [ ] Test with orders that have small numbers (< 1000)
- [ ] Test with orders that have large numbers (> 1000)
- [ ] Verify in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)