### PR TITLE
fix(auth): add claims polling to prevent first access permission denied

### DIFF
--- a/lib/mobx/invite_store.dart
+++ b/lib/mobx/invite_store.dart
@@ -1,6 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart';
 import 'package:mobx/mobx.dart';
 import 'package:praticos/global.dart';
 import 'package:praticos/models/invite.dart';
@@ -131,10 +130,7 @@ abstract class _InviteStore with Store {
 
       // 5. Wait for Cloud Function to update custom claims
       // This prevents "permission denied" errors on first access
-      final claimsUpdated = await ClaimsService.instance.waitForCompanyClaim(companyId);
-      if (!claimsUpdated) {
-        debugPrint('⚠️ Claims not updated within timeout after accepting invite');
-      }
+      await ClaimsService.instance.waitForCompanyClaim(companyId);
 
       // 6. Recarrega convites
       await loadPendingInvites();

--- a/lib/screens/onboarding/confirm_bootstrap_screen.dart
+++ b/lib/screens/onboarding/confirm_bootstrap_screen.dart
@@ -129,10 +129,7 @@ class _ConfirmBootstrapScreenState extends State<ConfirmBootstrapScreen> {
         // Wait for Cloud Function to update custom claims BEFORE any other operations
         // This prevents "permission denied" errors when creating sample data
         setState(() => _statusMessage = context.l10n.preparing);
-        final claimsUpdated = await ClaimsService.instance.waitForCompanyClaim(targetCompanyId);
-        if (!claimsUpdated) {
-          debugPrint('⚠️ Claims not updated within timeout, proceeding anyway');
-        }
+        await ClaimsService.instance.waitForCompanyClaim(targetCompanyId);
 
         setState(() => _statusMessage = context.l10n.importingForms);
         final bootstrapService = BootstrapService();
@@ -189,10 +186,7 @@ class _ConfirmBootstrapScreenState extends State<ConfirmBootstrapScreen> {
         // Wait for Cloud Function to update custom claims BEFORE any other operations
         // This prevents "permission denied" errors when creating sample data
         setState(() => _statusMessage = context.l10n.preparing);
-        final claimsUpdated = await ClaimsService.instance.waitForCompanyClaim(targetCompanyId);
-        if (!claimsUpdated) {
-          debugPrint('⚠️ Claims not updated within timeout, proceeding anyway');
-        }
+        await ClaimsService.instance.waitForCompanyClaim(targetCompanyId);
 
         setState(() => _statusMessage = context.l10n.importingForms);
         final bootstrapService = BootstrapService();

--- a/lib/screens/onboarding/welcome_screen.dart
+++ b/lib/screens/onboarding/welcome_screen.dart
@@ -131,10 +131,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
 
       // Wait for Cloud Function to update custom claims
       // This prevents "permission denied" errors on first access
-      final claimsUpdated = await ClaimsService.instance.waitForCompanyClaim(companyId);
-      if (!claimsUpdated) {
-        debugPrint('⚠️ Claims not updated within timeout, proceeding anyway');
-      }
+      await ClaimsService.instance.waitForCompanyClaim(companyId);
 
       if (mounted) {
         // Navega E força rebuild completo removendo todas as rotas

--- a/lib/services/bootstrap_service.dart
+++ b/lib/services/bootstrap_service.dart
@@ -512,43 +512,7 @@ class BootstrapService {
       skippedOrders: skippedOrders,
     );
 
-    await _saveMetadata(companyId, segmentId, subspecialties, result);
-
     return result;
-  }
-
-  /// Salva metadata do bootstrap executado
-  Future<void> _saveMetadata(
-    String companyId,
-    String segmentId,
-    List<String> subspecialties,
-    BootstrapResult result,
-  ) async {
-    await _db
-        .collection('companies')
-        .doc(companyId)
-        .collection('metadata')
-        .doc('bootstrap')
-        .set({
-      'executedAt': FieldValue.serverTimestamp(),
-      'userOptedIn': true,
-      'segment': segmentId,
-      'subspecialties': subspecialties,
-      'created': {
-        'services': result.createdServices,
-        'products': result.createdProducts,
-        'devices': result.createdDevices,
-        'customers': result.createdCustomers,
-        'orders': result.createdOrders,
-      },
-      'skipped': {
-        'services': result.skippedServices,
-        'products': result.skippedProducts,
-        'devices': result.skippedDevices,
-        'customers': result.skippedCustomers,
-        'orders': result.skippedOrders,
-      },
-    });
   }
 
   /// Cria OSs de exemplo com dados localizados

--- a/lib/services/claims_service.dart
+++ b/lib/services/claims_service.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart';
 
 /// Service for handling Firebase custom claims operations.
 ///
@@ -61,10 +60,6 @@ class ClaimsService {
       final hasAccess = await _checkCompanyAccess(companyId);
       if (hasAccess) {
         stopwatch.stop();
-        debugPrint(
-          '[ClaimsService] Claims updated for company $companyId '
-          'after ${stopwatch.elapsedMilliseconds}ms',
-        );
         return true;
       }
 
@@ -72,10 +67,6 @@ class ClaimsService {
     }
 
     stopwatch.stop();
-    debugPrint(
-      '[ClaimsService] Timeout waiting for claims for company $companyId '
-      'after ${stopwatch.elapsedMilliseconds}ms',
-    );
     return false;
   }
 
@@ -97,15 +88,8 @@ class ClaimsService {
       final roles = claims['roles'];
       if (roles == null || roles is! Map) return false;
 
-      final hasCompany = roles.containsKey(companyId);
-      debugPrint(
-        '[ClaimsService] Checking claims - roles: $roles, '
-        'hasCompany($companyId): $hasCompany',
-      );
-
-      return hasCompany;
+      return roles.containsKey(companyId);
     } catch (e) {
-      debugPrint('[ClaimsService] Error checking claims: $e');
       return false;
     }
   }
@@ -122,7 +106,6 @@ class ClaimsService {
       final tokenResult = await user.getIdTokenResult(true);
       return tokenResult.claims;
     } catch (e) {
-      debugPrint('[ClaimsService] Error getting claims: $e');
       return null;
     }
   }
@@ -134,9 +117,8 @@ class ClaimsService {
   Future<void> forceTokenRefresh() async {
     try {
       await FirebaseAuth.instance.currentUser?.getIdToken(true);
-      debugPrint('[ClaimsService] Token refreshed');
     } catch (e) {
-      debugPrint('[ClaimsService] Error refreshing token: $e');
+      // Silently ignore refresh errors
     }
   }
 }


### PR DESCRIPTION
## Summary

- Added `ClaimsService` with `waitForCompanyClaim()` method that polls Firebase Auth token until custom claims are updated
- Integrated claims polling in onboarding flows (WelcomeScreen, ConfirmBootstrapScreen) and invite acceptance (InviteStore)
- Removed unused bootstrap metadata saving

## Problem

After user signup or invite acceptance, custom claims are set by a Cloud Function with 100-800ms latency. The client token remains cached with old claims, causing "permission denied" errors on first access to company data.

## Solution

The `ClaimsService` polls the token every 500ms (up to 10s) until the claims contain the expected companyId. This ensures the user has proper access before any Firestore operations that require company membership.

```
1. createCompanyForUser() or acceptInvite()
2. waitForCompanyClaim(companyId)  ← New polling step
3. Continue with Firestore operations
```

## Test plan

- [ ] Test new user signup with "skip onboarding" flow
- [ ] Test new user signup with full onboarding flow (with sample data)
- [ ] Test accepting an invite as a new user
- [ ] Verify no permission denied errors on first access

🤖 Generated with [Claude Code](https://claude.com/claude-code)