### PR TITLE
feat(website): add automatic lastmod to sitemap.xml

### DIFF
--- a/firebase/hosting/.eleventy.js
+++ b/firebase/hosting/.eleventy.js
@@ -51,6 +51,11 @@ module.exports = function(eleventyConfig) {
     return (path || "").replace(/^\/+/, "");
   });
 
+  // Format a date as YYYY-MM-DD for sitemap <lastmod>
+  eleventyConfig.addFilter("dateToISO", function(date) {
+    return date.toISOString().split('T')[0];
+  });
+
   return {
     dir: {
       input: "src",

--- a/firebase/hosting/src/sitemap.njk
+++ b/firebase/hosting/src/sitemap.njk
@@ -9,6 +9,7 @@ eleventyExcludeFromCollections: true
 {%- if page.url and page.url != '/404.html' and not page.url.startsWith('/login') and not page.url.startsWith('/order') and page.url != '/sitemap.xml' %}
   <url>
     <loc>{{ site.baseUrl }}{{ page.url }}</loc>
+    <lastmod>{{ page.date | dateToISO }}</lastmod>
     {%- if page.data.langSwitch %}
     {%- set hreflangMap = { "PT": "pt-BR", "EN": "en", "ES": "es" } %}
     {%- for langItem in page.data.langSwitch %}

--- a/firebase/hosting/src/src.11tydata.js
+++ b/firebase/hosting/src/src.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  date: "Last Modified"
+};


### PR DESCRIPTION
## Summary
- Add `<lastmod>` dates to sitemap.xml using Eleventy's `Last Modified` date strategy
- Dates auto-update based on source file mtime — no manual intervention needed
- Improves crawl budget optimization as recommended by Google

## Changes
- **`.eleventy.js`**: Added `dateToISO` filter to format dates as `YYYY-MM-DD`
- **`src/sitemap.njk`**: Added `<lastmod>` tag to each `<url>` entry
- **`src/src.11tydata.js`** (new): Sets `date: "Last Modified"` globally for all pages

## Test plan
- [x] `npm run build` generates sitemap with `<lastmod>` dates
- [x] `xmllint --noout public/sitemap.xml` validates successfully
- [x] Dates reflect actual file modification times (varying per page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)