### PR TITLE
fix: bot não respeita fuso horário em agendamentos/cron

### DIFF
--- a/backend/bot/workspace/SOUL.md
+++ b/backend/bot/workspace/SOUL.md
@@ -114,6 +114,8 @@ Eu persisto entre sessoes usando dois niveis de memoria:
 - **Nome:** [userName] | **VAK:** [detectar] | **Prefere:** [observar]
 ## Empresa & Segmento
 - **Empresa:** [companyName] | **Segmento:** [segment.name]
+## Fuso Horário
+- **Timezone:** America/Sao_Paulo (UTC-3)
 ## Terminologia (segment.labels)
 [copiar TODOS os labels do context, um por linha]
 ## Notas

--- a/backend/bot/workspace/skills/praticos/SKILL.md
+++ b/backend/bot/workspace/skills/praticos/SKILL.md
@@ -33,6 +33,11 @@ Cron perde o contexto do usuario (origin.from). Para garantir entrega CORRETA:
 3. Em TODA chamada API no cron: usar o {NUMERO} salvo no header X-WhatsApp-Number
 4. 🔴 Para enviar resposta: SEMPRE usar sessions_send com sessionKey="agent:main:whatsapp:dm:{NUMERO}". NUNCA usar message() no cron — message() envia para a sessao do cron (webchat), NAO para o WhatsApp do usuario
 5. Se NAO conseguir determinar {NUMERO}: NAO executar — esperar proxima msg do usuario
+6. **FUSO HORÁRIO (OBRIGATÓRIO):**
+   - O cron trabalha em UTC. Quando o usuário pedir horário (ex: "9h", "manhã", "às 14h"), SEMPRE converter para UTC antes de agendar
+   - Fuso padrão: **America/Sao_Paulo (UTC-3)**. Ex: 09:00 BRT → 12:00 UTC
+   - Ao confirmar, SEMPRE mostrar horário local: "Agendado para 09:00 (horário de Brasília) ✅"
+   - NUNCA exibir "UTC" para o usuário
 
 ---
 


### PR DESCRIPTION
## Summary
- Adiciona regra de conversão de timezone (BRT→UTC) na seção CRON do `SKILL.md`
- Adiciona campo `timezone` no template de memória do usuário em `SOUL.md`
- Default fixo: `America/Sao_Paulo (UTC-3)` para todos os usuários

## Test plan
- [ ] Enviar mensagem ao bot pedindo lembrete com horário específico (ex: "me lembra às 9h")
- [ ] Confirmar que horário exibido na confirmação está em BRT (não UTC)
- [ ] Verificar que o cron job usa o offset correto (-3h para UTC)

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)