### PR TITLE
feat(marketing): add Facebook Pixel tracking

### DIFF
--- a/firebase/hosting/src/_data/site.json
+++ b/firebase/hosting/src/_data/site.json
@@ -13,6 +13,7 @@
     "orders": "10k+",
     "rating": "4.8"
   },
+  "facebookPixelId": "1690631042320225",
   "whatsapp": {
     "number": "554888794742",
     "messages": {

--- a/firebase/hosting/src/_includes/partials/head.njk
+++ b/firebase/hosting/src/_includes/partials/head.njk
@@ -69,6 +69,25 @@
   });
 </script>
 
+<!-- Facebook Pixel -->
+{% if site.facebookPixelId %}
+<script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '{{ site.facebookPixelId }}');
+  fbq('track', 'PageView');
+</script>
+<noscript><img height="1" width="1" style="display:none"
+  src="https://www.facebook.com/tr?id={{ site.facebookPixelId }}&ev=PageView&noscript=1"
+/></noscript>
+{% endif %}
+
 <!-- Structured Data -->
 <script type="application/ld+json">
 {

--- a/firebase/hosting/src/_includes/partials/scripts.njk
+++ b/firebase/hosting/src/_includes/partials/scripts.njk
@@ -112,3 +112,38 @@
   }
 })();
 </script>
+{% if site.facebookPixelId %}
+<script>
+// Facebook Pixel Event Tracking
+(function() {
+  if (typeof fbq !== 'function') return;
+
+  // Track CTA clicks (download buttons, store links)
+  document.addEventListener('click', function(e) {
+    var storeLink = e.target.closest('a[href*="apps.apple.com"], a[href*="play.google.com"]');
+    if (storeLink) {
+      var store = storeLink.href.indexOf('apple') !== -1 ? 'app_store' : 'play_store';
+      fbq('track', 'Lead', { content_name: 'app_download', content_category: store });
+    }
+
+    var whatsappLink = e.target.closest('a[href*="wa.me"], a[href*="whatsapp"]');
+    if (whatsappLink) {
+      fbq('track', 'Contact', { content_name: 'whatsapp' });
+    }
+
+    var ctaBtn = e.target.closest('[data-ga="cta_click"]');
+    if (ctaBtn) {
+      fbq('track', 'InitiateCheckout', { content_name: ctaBtn.getAttribute('data-ga-detail') || 'cta' });
+    }
+  });
+
+  // Track contact form submission
+  var form = document.querySelector('.contact-form');
+  if (form) {
+    form.addEventListener('submit', function() {
+      fbq('track', 'Lead', { content_name: 'contact_form' });
+    });
+  }
+})();
+</script>
+{% endif %}


### PR DESCRIPTION
## Summary
- Add Facebook Pixel (ID: 1690631042320225) to all website pages via configurable `site.json` field
- Track PageView on every page load with noscript fallback
- Track conversion events: app store clicks (Lead), WhatsApp contact (Contact), CTA buttons (InitiateCheckout), and contact form (Lead)

## Test plan
- [x] Build passes (85 pages generated)
- [x] Pixel renders correctly when `facebookPixelId` is set
- [x] Pixel is excluded when `facebookPixelId` is empty
- [x] Deployed to praticos.web.app
- [ ] Verify with Meta Pixel Helper Chrome extension
- [ ] Confirm events appear in Facebook Events Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)