### PR TITLE
fix(ci): use explicit ref in auto-version push to avoid ambiguous ref…

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -160,7 +160,7 @@ jobs:
 
           git add pubspec.yaml
           git commit -m "chore(release): bump version to ${{ steps.version.outputs.version }} [skip ci]"
-          git push origin master
+          git push origin HEAD:refs/heads/master
 
       - name: Create and push tag
         env:


### PR DESCRIPTION
…name

The `git push origin master` command was failing because a tag named `master` existed, making the refname ambiguous. Using explicit `HEAD:refs/heads/master` ensures only the branch is targeted.