### PR TITLE
feat: WhatsApp adoption nudges, invite refactor & Play Store ASO

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
-        android:label="praticos"
+        android:label="PraticOS"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/android/fastlane/metadata/android/en-US/full_description.txt
@@ -1,4 +1,4 @@
-Simplify your business management with PraticOS, the complete app for managing work orders, customers, and finances in one place.
+PraticOS is the most practical work order management app on the market. Track work orders, customers, and finances all in one place. Built for repair shops, field service teams, and independent professionals.
 
 WORK ORDER MANAGEMENT
 • Create and track work orders with ease

--- a/android/fastlane/metadata/android/en-US/short_description.txt
+++ b/android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Manage work orders and customers simply and practically.
+Work order management, customers & finances. Simple and complete!

--- a/android/fastlane/metadata/android/en-US/title.txt
+++ b/android/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-PraticOS
+PraticOS - Work Order App

--- a/android/fastlane/metadata/android/es-ES/full_description.txt
+++ b/android/fastlane/metadata/android/es-ES/full_description.txt
@@ -1,4 +1,4 @@
-Simplifique la gestión de su negocio con PraticOS, la app completa para administrar órdenes de servicio, clientes y finanzas en un solo lugar.
+PraticOS es la app de gestión de órdenes de servicio más práctica del mercado. Controle OS, clientes y finanzas en un solo lugar. Ideal para talleres, asistencia técnica y proveedores de servicios.
 
 GESTIÓN DE ÓRDENES DE SERVICIO
 • Cree y rastree órdenes de servicio con facilidad

--- a/android/fastlane/metadata/android/es-ES/short_description.txt
+++ b/android/fastlane/metadata/android/es-ES/short_description.txt
@@ -1,1 +1,1 @@
-Administre órdenes de servicio y clientes de forma simple y práctica.
+Gestión de órdenes de servicio, clientes y finanzas. Simple y completo!

--- a/android/fastlane/metadata/android/es-ES/title.txt
+++ b/android/fastlane/metadata/android/es-ES/title.txt
@@ -1,1 +1,1 @@
-PraticOS
+PraticOS - Orden de Servicio

--- a/android/fastlane/metadata/android/pt-BR/full_description.txt
+++ b/android/fastlane/metadata/android/pt-BR/full_description.txt
@@ -1,4 +1,4 @@
-Simplifique a gestão do seu negócio com o PraticOS, o app completo para gerenciar ordens de serviço, clientes e finanças em um só lugar.
+PraticOS é o app de gestão de ordens de serviço mais prático do mercado. Controle OS, clientes e finanças em um só lugar. Ideal para oficinas, assistências técnicas e prestadores de serviço.
 
 GESTÃO DE ORDENS DE SERVIÇO
 • Crie e acompanhe ordens de serviço com facilidade

--- a/android/fastlane/metadata/android/pt-BR/short_description.txt
+++ b/android/fastlane/metadata/android/pt-BR/short_description.txt
@@ -1,1 +1,1 @@
-Gerencie ordens de serviço e clientes de forma simples e prática.
+Gestão de ordens de serviço, clientes e financeiro. Simples e completo!

--- a/android/fastlane/metadata/android/pt-BR/title.txt
+++ b/android/fastlane/metadata/android/pt-BR/title.txt
@@ -1,1 +1,1 @@
-PraticOS
+PraticOS - Ordem de Serviço


### PR DESCRIPTION
## Summary

- **WhatsApp adoption**: Add nudges across the app (home banner, order form, onboarding screen, collaborator sharing) to drive WhatsApp bot setup, with dismissible banners and smart triggers
- **Invite system refactor**: Use typed exceptions, API-based acceptance, and code-based sharing instead of direct Firestore writes
- **Facebook Pixel**: Add tracking to the institutional website
- **Play Store ASO**: Optimize titles, descriptions, and metadata across pt-BR/en-US/es-ES for better search ranking on Google Play
- **CI fix**: Use explicit ref in auto-version push to avoid ambiguous refname
- **Share links**: Add status-aware share prompts and fix API URL

## Test plan

- [ ] Verify WhatsApp setup banner appears on home screen for users without WhatsApp configured
- [ ] Verify banner can be dismissed and stays dismissed
- [ ] Verify WhatsApp nudge appears after completing an order
- [ ] Verify invite sharing flow works with new code-based system
- [ ] Verify collaborator form/list screens work correctly
- [ ] Verify Play Store metadata is within character limits (titles ≤30, short desc ≤80, full desc ≤4000)
- [ ] Verify AndroidManifest label shows "PraticOS" on device home screen
- [ ] Run `fvm flutter analyze` with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)