### PR TITLE
feat(website): add light theme with blue-slate palette

### DIFF
--- a/firebase/hosting/src/_includes/partials/head.njk
+++ b/firebase/hosting/src/_includes/partials/head.njk
@@ -5,6 +5,16 @@
 <meta name="keywords" content="{{ keywords }}">
 <meta name="robots" content="index, follow">
 
+<!-- Anti-FOUC: apply saved theme before CSS loads -->
+<script>
+(function(){
+  try{var s=localStorage.getItem('theme')}catch(e){var s=null}
+  var t=s||(window.matchMedia('(prefers-color-scheme:light)').matches?'light':'dark');
+  document.documentElement.setAttribute('data-theme',t);
+})();
+</script>
+<meta name="theme-color" content="#0A0E17" id="meta-theme-color">
+
 <!-- Canonical URL -->
 <link rel="canonical" href="{{ permalink | prettyUrl | siteUrl(site.baseUrl) }}">
 

--- a/firebase/hosting/src/_includes/partials/mobile-menu.njk
+++ b/firebase/hosting/src/_includes/partials/mobile-menu.njk
@@ -28,6 +28,10 @@
             {% for langItem in langSwitch %}
             <a href="{{ langItem.href | prettyUrl }}"{% if langItem.active %} class="active"{% endif %} data-ga="select_content" data-ga-detail="lang_{{ langItem.code | lower }}">{{ langItem.code }}</a>
             {% endfor %}
+            <button class="mobile-theme-toggle" aria-label="Toggle theme">
+                <svg class="theme-icon-sun" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+                <svg class="theme-icon-moon" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
         <a href="{% if not isHomepage %}{{ relPath }}{{ indexPage | default('index.html') | prettyUrl }}{% endif %}#download" class="btn btn-primary" data-ga="select_content" data-ga-detail="navbar_cta_mobile">{{ nav.cta }}</a>
     </div>

--- a/firebase/hosting/src/_includes/partials/navbar.njk
+++ b/firebase/hosting/src/_includes/partials/navbar.njk
@@ -38,6 +38,10 @@
                 <a href="{{ langItem.href | prettyUrl }}"{% if langItem.active %} class="active"{% endif %} data-ga="select_content" data-ga-detail="lang_{{ langItem.code | lower }}">{{ langItem.code }}</a>
                 {% endfor %}
             </div>
+            <button class="theme-toggle" aria-label="Toggle theme">
+                <svg class="theme-icon-sun" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+                <svg class="theme-icon-moon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
             <a href="{% if not isHomepage and not segmentSlug %}{{ relPath }}{{ indexPage | default('index.html') | prettyUrl }}{% endif %}#download" class="btn btn-primary" data-ga="select_content" data-ga-detail="navbar_cta">{{ nav.cta }}</a>
         </div>
         <button class="nav-toggle" aria-label="Menu">

--- a/firebase/hosting/src/_includes/partials/scripts.njk
+++ b/firebase/hosting/src/_includes/partials/scripts.njk
@@ -1,4 +1,52 @@
 <script>
+    // Theme toggle logic
+    (function() {
+        var html = document.documentElement;
+        var metaTheme = document.getElementById('meta-theme-color');
+
+        function getTheme() {
+            return html.getAttribute('data-theme') || 'dark';
+        }
+
+        function setTheme(theme) {
+            html.classList.add('theme-transitioning');
+            html.setAttribute('data-theme', theme);
+            if (metaTheme) {
+                metaTheme.setAttribute('content', theme === 'light' ? '#EDF1F9' : '#0A0E17');
+            }
+            try { localStorage.setItem('theme', theme); } catch(e) {}
+            setTimeout(function() {
+                html.classList.remove('theme-transitioning');
+            }, 350);
+        }
+
+        function toggleTheme() {
+            setTheme(getTheme() === 'dark' ? 'light' : 'dark');
+        }
+
+        // Bind all toggle buttons
+        document.querySelectorAll('.theme-toggle, .mobile-theme-toggle').forEach(function(btn) {
+            btn.addEventListener('click', toggleTheme);
+        });
+
+        // Listen for OS theme changes (only when no saved preference)
+        try {
+            if (!localStorage.getItem('theme')) {
+                window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function(e) {
+                    if (!localStorage.getItem('theme')) {
+                        setTheme(e.matches ? 'light' : 'dark');
+                    }
+                });
+            }
+        } catch(e) {}
+
+        // Set initial meta theme-color
+        if (metaTheme) {
+            metaTheme.setAttribute('content', getTheme() === 'light' ? '#EDF1F9' : '#0A0E17');
+        }
+    })();
+</script>
+<script>
     // Mobile menu toggle
     const navToggle = document.querySelector('.nav-toggle');
     const mobileMenu = document.querySelector('.mobile-menu');

--- a/firebase/hosting/src/css/docs.css
+++ b/firebase/hosting/src/css/docs.css
@@ -1372,3 +1372,30 @@
         grid-template-columns: 1fr;
     }
 }
+
+/* ============================================
+   Light Theme Overrides
+   ============================================ */
+[data-theme="light"] .docs-search:focus-within {
+    box-shadow: 0 0 0 3px rgba(43, 123, 192, 0.15);
+}
+
+[data-theme="light"] .category-card,
+[data-theme="light"] .quick-link,
+[data-theme="light"] .profile-card,
+[data-theme="light"] .permission-category,
+[data-theme="light"] .metric-card,
+[data-theme="light"] .feature-item,
+[data-theme="light"] .feature-block,
+[data-theme="light"] .status-card,
+[data-theme="light"] .pdf-preview {
+    box-shadow: var(--shadow-sm);
+}
+
+[data-theme="light"] .category-card:hover {
+    box-shadow: var(--shadow-md);
+}
+
+[data-theme="light"] .category-badge {
+    color: #FFFFFF;
+}

--- a/firebase/hosting/src/css/feature.css
+++ b/firebase/hosting/src/css/feature.css
@@ -64,8 +64,8 @@
     position: absolute;
     inset: 0;
     background-image:
-        linear-gradient(rgba(255,255,255,0.015) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(255,255,255,0.015) 1px, transparent 1px);
+        linear-gradient(var(--grid-line-color) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-line-color) 1px, transparent 1px);
     background-size: 60px 60px;
     mask-image: radial-gradient(ellipse 70% 60% at 50% 40%, black 30%, transparent 80%);
     -webkit-mask-image: radial-gradient(ellipse 70% 60% at 50% 40%, black 30%, transparent 80%);
@@ -738,4 +738,41 @@
     .feature-demo-content .feature-demo-cta .btn {
         width: 100%;
     }
+}
+
+/* ============================================
+   Light Theme Overrides
+   ============================================ */
+[data-theme="light"] .feature-hero .gradient-orb {
+    opacity: 0.1;
+}
+
+[data-theme="light"] .feature-phone-frame {
+    box-shadow:
+        0 24px 64px rgba(0, 0, 0, 0.12),
+        0 0 0 1px var(--border-color),
+        0 0 80px rgba(37, 211, 102, 0.06);
+}
+
+[data-theme="light"] .feature-phone-frame:hover {
+    box-shadow:
+        0 32px 80px rgba(0, 0, 0, 0.16),
+        0 0 0 1px var(--border-color-hover),
+        0 0 120px rgba(37, 211, 102, 0.08);
+}
+
+[data-theme="light"] .feature-phone-glow {
+    opacity: 0.06;
+}
+
+[data-theme="light"] .feature-grid-card:hover,
+[data-theme="light"] .feature-media-card:hover,
+[data-theme="light"] .feature-highlight-card:hover {
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .feature-grid-card,
+[data-theme="light"] .feature-media-card,
+[data-theme="light"] .feature-highlight-card {
+    box-shadow: var(--shadow-sm);
 }

--- a/firebase/hosting/src/css/order-view.css
+++ b/firebase/hosting/src/css/order-view.css
@@ -1167,3 +1167,30 @@
         padding-bottom: calc(100px + env(safe-area-inset-bottom));
     }
 }
+
+/* ============================================
+   Light Theme Overrides
+   ============================================ */
+[data-theme="light"] .order-header::before {
+    background: radial-gradient(circle, rgba(43, 123, 192, 0.06) 0%, transparent 70%);
+}
+
+[data-theme="light"] .modal-overlay {
+    background: rgba(0, 0, 0, 0.5);
+}
+
+[data-theme="light"] .lightbox-overlay {
+    background: rgba(0, 0, 0, 0.9);
+}
+
+[data-theme="light"] .order-card {
+    box-shadow: var(--shadow-sm);
+}
+
+[data-theme="light"] .total-section {
+    background: linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-card) 100%);
+}
+
+[data-theme="light"] .photo-item:hover {
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}

--- a/firebase/hosting/src/css/support.css
+++ b/firebase/hosting/src/css/support.css
@@ -165,3 +165,59 @@
     color: rgba(255, 255, 255, 0.7);
     margin-bottom: 24px;
 }
+
+/* ============================================
+   Light Theme Overrides
+   ============================================ */
+[data-theme="light"] .support-card {
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.02), rgba(0, 0, 0, 0.04));
+    border-color: rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+[data-theme="light"] .support-card:hover {
+    border-color: rgba(255, 111, 15, 0.3);
+    box-shadow: 0 8px 24px rgba(255, 111, 15, 0.12);
+}
+
+[data-theme="light"] .support-card h3,
+[data-theme="light"] .contact-methods h3,
+[data-theme="light"] .faq-preview h3,
+[data-theme="light"] .faq-quick-item h4,
+[data-theme="light"] .need-help-section h3,
+[data-theme="light"] .contact-item-content h4 {
+    color: var(--text-primary);
+}
+
+[data-theme="light"] .support-card p,
+[data-theme="light"] .contact-item-content p,
+[data-theme="light"] .faq-quick-item p,
+[data-theme="light"] .need-help-section p {
+    color: var(--text-secondary);
+}
+
+[data-theme="light"] .contact-methods {
+    background: linear-gradient(135deg, rgba(255, 111, 15, 0.06), rgba(255, 212, 58, 0.06));
+    border-color: rgba(255, 111, 15, 0.15);
+}
+
+[data-theme="light"] .contact-item {
+    border-bottom-color: rgba(0, 0, 0, 0.06);
+}
+
+[data-theme="light"] .contact-item-icon {
+    background: rgba(255, 111, 15, 0.1);
+}
+
+[data-theme="light"] .faq-preview {
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.02), rgba(0, 0, 0, 0.01));
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .faq-quick-item {
+    border-bottom-color: rgba(0, 0, 0, 0.06);
+}
+
+[data-theme="light"] .need-help-section {
+    background: linear-gradient(135deg, rgba(255, 111, 15, 0.06), rgba(255, 212, 58, 0.06));
+}

--- a/firebase/hosting/src/order/index.njk
+++ b/firebase/hosting/src/order/index.njk
@@ -4,6 +4,13 @@ layout: false
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
+    <script>
+    (function(){
+      try{var s=localStorage.getItem('theme')}catch(e){var s=null}
+      var t=s||(window.matchMedia('(prefers-color-scheme:light)').matches?'light':'dark');
+      document.documentElement.setAttribute('data-theme',t);
+    })();
+    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Acompanhe sua OS - PraticOS</title>
@@ -28,7 +35,7 @@ layout: false
     <meta property="og:type" content="website">
 
     <!-- Theme Color -->
-    <meta name="theme-color" content="#0A0E17">
+    <meta name="theme-color" content="#0A0E17" id="meta-theme-color">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 </head>
 <body>

--- a/firebase/hosting/src/style.css
+++ b/firebase/hosting/src/style.css
@@ -46,6 +46,13 @@
     --shadow-lg: 0 8px 40px rgba(0, 0, 0, 0.5);
     --shadow-glow: 0 0 60px rgba(74, 155, 217, 0.3);
 
+    /* Theme-specific */
+    --navbar-bg: rgba(10, 14, 23, 0.95);
+    --dropdown-bg: rgba(10, 14, 23, 0.98);
+    --orb-opacity: 0.4;
+    --grid-line-color: rgba(255, 255, 255, 0.015);
+    --btn-primary-text: var(--bg-primary);
+
     /* Typography */
     --font-heading: 'Outfit', sans-serif;
     --font-body: 'DM Sans', sans-serif;
@@ -65,6 +72,212 @@
     --radius-lg: 20px;
     --radius-xl: 28px;
     --radius-full: 9999px;
+}
+
+/* ============================================
+   Light Theme
+   ============================================ */
+[data-theme="light"] {
+    --color-primary: #2B7BC0;
+    --color-primary-light: #4A9BD9;
+    --color-primary-dark: #1E5A8A;
+
+    --bg-primary: #EDF1F9;
+    --bg-secondary: #E3E8F4;
+    --bg-tertiary: #D9DFEE;
+    --bg-card: #FAFBFE;
+    --bg-card-hover: #FFFFFF;
+
+    --text-primary: #2D3748;
+    --text-secondary: #4A5568;
+    --text-tertiary: #718096;
+    --text-muted: #A0AEC0;
+
+    --border-color: rgba(30, 60, 120, 0.08);
+    --border-color-hover: rgba(30, 60, 120, 0.15);
+
+    --gradient-hero: linear-gradient(180deg, #EDF1F9 0%, #E3E8F4 100%);
+    --gradient-card: linear-gradient(145deg, #FAFBFE 0%, #EDF1F9 100%);
+
+    --shadow-sm: 0 1px 3px rgba(30,50,100,0.07), 0 1px 2px rgba(30,50,100,0.05);
+    --shadow-md: 0 4px 14px rgba(30,50,100,0.09), 0 2px 4px rgba(30,50,100,0.05);
+    --shadow-lg: 0 8px 28px rgba(30,50,100,0.11), 0 4px 8px rgba(30,50,100,0.06);
+    --shadow-glow: 0 0 40px rgba(43,123,192,0.18);
+
+    --gradient-primary: linear-gradient(135deg, #2B7BC0 0%, #1E5A8A 100%);
+
+    --navbar-bg: rgba(237, 241, 249, 0.88);
+    --dropdown-bg: rgba(237, 241, 249, 0.96);
+    --orb-opacity: 0.20;
+    --grid-line-color: rgba(30, 60, 120, 0.025);
+    --btn-primary-text: #FFFFFF;
+}
+
+/* Smooth theme transition */
+html.theme-transitioning,
+html.theme-transitioning *,
+html.theme-transitioning *::before,
+html.theme-transitioning *::after {
+    transition: background-color 0.35s ease, color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, background 0.35s ease !important;
+}
+
+/* Light theme - card elevation via shadow + white background */
+[data-theme="light"] .feature-card,
+[data-theme="light"] .pricing-card,
+[data-theme="light"] .contact-card,
+[data-theme="light"] .faq-item,
+[data-theme="light"] .store-button,
+[data-theme="light"] .phone-mockup,
+[data-theme="light"] .contact-form,
+[data-theme="light"] .support-form {
+    box-shadow: var(--shadow-sm);
+}
+
+[data-theme="light"] .phone-frame {
+    box-shadow: 0 12px 40px rgba(30,50,100,0.12), 0 4px 12px rgba(30,50,100,0.08);
+}
+
+[data-theme="light"] .feature-card:hover,
+[data-theme="light"] .pricing-card:hover,
+[data-theme="light"] .contact-card:hover,
+[data-theme="light"] .store-button:hover {
+    box-shadow: var(--shadow-md);
+}
+
+/* Light theme - hero depth: radial blue glow */
+[data-theme="light"] .hero-bg::after {
+    content: '';
+    position: absolute;
+    top: -15%;
+    right: -10%;
+    width: 65%;
+    height: 65%;
+    background: radial-gradient(ellipse, rgba(43,123,192,0.07) 0%, transparent 70%);
+    pointer-events: none;
+}
+
+/* Light theme - button shadow: blue-tinted */
+[data-theme="light"] .btn-primary {
+    box-shadow: 0 4px 20px rgba(30, 90, 138, 0.35);
+}
+
+[data-theme="light"] .btn-primary:hover {
+    box-shadow: 0 8px 30px rgba(30, 90, 138, 0.45);
+}
+
+/* Light theme - gradient text: deep blue → teal */
+[data-theme="light"] .gradient-text {
+    background: linear-gradient(135deg, #1E5A8A 0%, #0E7C6B 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+/* Light theme - stat numbers */
+[data-theme="light"] .stat-number {
+    background: linear-gradient(135deg, #2B7BC0 0%, #0E7C6B 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+/* Light theme - featured pricing card */
+[data-theme="light"] .pricing-card.featured {
+    background: linear-gradient(165deg, #FFFFFF 0%, rgba(43,123,192,0.08) 100%);
+    box-shadow: 0 8px 40px rgba(43,123,192,0.14);
+}
+
+/* Light theme - phone glow: blue tint instead of hide */
+[data-theme="light"] .phone-glow,
+[data-theme="light"] .wa-phone-glow {
+    opacity: 0.10;
+}
+
+/* Light theme - pricing page header */
+[data-theme="light"] .pricing-page-header {
+    background: linear-gradient(180deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
+}
+
+/* Light theme - differentials card */
+[data-theme="light"] .differentials-card {
+    background: linear-gradient(165deg, #FFFFFF 0%, rgba(43,123,192,0.06) 100%);
+}
+
+/* Light theme - section tag / badge visibility */
+[data-theme="light"] .section-tag {
+    background: rgba(43, 123, 192, 0.10);
+    border-color: rgba(43, 123, 192, 0.22);
+}
+
+[data-theme="light"] .badge {
+    background: rgba(43, 123, 192, 0.10);
+    border-color: rgba(43, 123, 192, 0.22);
+}
+
+/* Light theme - logo yellow too bright on light bg */
+[data-theme="light"] .logo-text .yellow,
+[data-theme="light"] .logo-text .accent {
+    color: #B8860B;
+}
+
+/* Light theme - navbar subtle bottom line before scroll */
+[data-theme="light"] .navbar {
+    border-bottom: 1px solid rgba(30, 60, 120, 0.04);
+}
+
+[data-theme="light"] .navbar.scrolled {
+    box-shadow: 0 1px 8px rgba(30,50,100,0.06);
+}
+
+/* Light theme - tinted elements for harmony */
+[data-theme="light"] .store-button {
+    background: #FAFBFE;
+    border-color: rgba(30, 60, 120, 0.12);
+    box-shadow: 0 2px 8px rgba(30,50,100,0.06);
+}
+
+[data-theme="light"] .store-button:hover {
+    background: #FFFFFF;
+    border-color: var(--color-primary);
+    box-shadow: var(--shadow-md);
+}
+
+[data-theme="light"] .phone-frame,
+[data-theme="light"] .phone-mockup,
+[data-theme="light"] .wa-phone-frame {
+    background: linear-gradient(165deg, #C8CED9 0%, #B0B8C7 50%, #C2C9D6 100%);
+    border-color: rgba(30, 60, 120, 0.15);
+}
+
+[data-theme="light"] .lang-switch a:hover,
+[data-theme="light"] .lang-switch a.active {
+    background: #E3E8F4;
+}
+
+[data-theme="light"] .contact-card {
+    background: #FAFBFE;
+    border-color: rgba(30, 60, 120, 0.10);
+}
+
+[data-theme="light"] .contact-form,
+[data-theme="light"] .support-form {
+    background: #FAFBFE;
+    border-color: rgba(30, 60, 120, 0.10);
+}
+
+[data-theme="light"] .contact-card:hover {
+    background: #FFFFFF;
+    border-color: var(--color-primary);
+}
+
+[data-theme="light"] .pricing-card {
+    background: #FAFBFE;
+    border-color: rgba(30, 60, 120, 0.10);
+}
+
+[data-theme="light"] .faq-item {
+    background: #FAFBFE;
+    border-color: rgba(30, 60, 120, 0.10);
 }
 
 /* Reset & Base */
@@ -153,7 +366,7 @@ h4 { font-size: 1.125rem; }
 
 .btn-primary {
     background: var(--gradient-primary);
-    color: var(--bg-primary);
+    color: var(--btn-primary-text);
     box-shadow: 0 4px 20px rgba(74, 155, 217, 0.4);
 }
 
@@ -219,7 +432,7 @@ h4 { font-size: 1.125rem; }
 }
 
 .navbar.scrolled {
-    background: rgba(10, 14, 23, 0.95);
+    background: var(--navbar-bg);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
     padding: 12px 0;
@@ -318,6 +531,77 @@ h4 { font-size: 1.125rem; }
     color: var(--text-primary);
     background: var(--bg-card);
 }
+
+/* Theme Toggle Button */
+.theme-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    color: var(--text-secondary);
+    padding: 0;
+}
+
+.theme-toggle:hover {
+    background: var(--bg-card);
+    color: var(--text-primary);
+    border-color: var(--border-color-hover);
+}
+
+.theme-toggle svg {
+    width: 20px;
+    height: 20px;
+    transition: transform 0.3s ease;
+}
+
+.theme-toggle:hover svg {
+    transform: rotate(15deg);
+}
+
+/* Show sun in dark mode, moon in light mode */
+.theme-icon-sun { display: block; }
+.theme-icon-moon { display: none; }
+
+[data-theme="light"] .theme-icon-sun { display: none; }
+[data-theme="light"] .theme-icon-moon { display: block; }
+
+/* Mobile theme toggle */
+.mobile-theme-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    color: var(--text-secondary);
+    padding: 0;
+}
+
+.mobile-theme-toggle:hover {
+    background: var(--bg-card);
+    color: var(--text-primary);
+}
+
+.mobile-theme-toggle svg {
+    width: 22px;
+    height: 22px;
+}
+
+.mobile-theme-toggle .theme-icon-sun { display: block; }
+.mobile-theme-toggle .theme-icon-moon { display: none; }
+
+[data-theme="light"] .mobile-theme-toggle .theme-icon-sun { display: none; }
+[data-theme="light"] .mobile-theme-toggle .theme-icon-moon { display: block; }
 
 /* Mobile Navigation Toggle */
 .nav-toggle {
@@ -448,7 +732,7 @@ h4 { font-size: 1.125rem; }
     top: 100%;
     left: 50%;
     transform: translateX(-50%);
-    background: rgba(10, 14, 23, 0.98);
+    background: var(--dropdown-bg);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
     border: 1px solid var(--border-color);
@@ -592,7 +876,7 @@ h4 { font-size: 1.125rem; }
     position: absolute;
     border-radius: 50%;
     filter: blur(80px);
-    opacity: 0.4;
+    opacity: var(--orb-opacity);
     animation: float 8s ease-in-out infinite;
 }
 
@@ -622,7 +906,7 @@ h4 { font-size: 1.125rem; }
     left: 50%;
     transform: translate(-50%, -50%);
     animation-delay: -4s;
-    opacity: 0.2;
+    opacity: calc(var(--orb-opacity) * 0.5);
 }
 
 @keyframes float {
@@ -1269,7 +1553,7 @@ h4 { font-size: 1.125rem; }
     transform: translateX(-50%);
     padding: 6px 16px;
     background: var(--gradient-primary);
-    color: var(--bg-primary);
+    color: var(--btn-primary-text);
     font-size: 0.7rem;
     font-weight: 700;
     text-transform: uppercase;
@@ -2149,7 +2433,7 @@ h4 { font-size: 1.125rem; }
 
 .support-form button {
     background: var(--gradient-primary);
-    color: var(--bg-primary);
+    color: var(--btn-primary-text);
     border: none;
     padding: 14px 28px;
     font-family: var(--font-body);


### PR DESCRIPTION
## Summary
- Add complete light theme for the PraticOS website with a premium blue-slate palette
- Replace flat white backgrounds with tinted blue-slate tones (`#EDF1F9` primary)
- Override gradient-primary to solid blue for light mode (buttons, badges, stats)
- Add metallic phone frame bezels, softer text, blue-tinted shadows, and hero radial glow

## Changes
- `style.css` — Full `[data-theme="light"]` block + component overrides
- `scripts.njk` — Theme toggle logic with meta theme-color sync
- `head.njk`, `navbar.njk`, `mobile-menu.njk` — Theme toggle buttons
- `docs.css`, `feature.css`, `support.css`, `order-view.css` — Light theme adaptations

## Test plan
- [ ] Toggle light/dark theme on homepage — verify smooth transition
- [ ] Check hero section: blue-slate bg, teal gradient text, blue buttons
- [ ] Check screenshots section: metallic phone frames
- [ ] Check pricing page: blue badges, tinted cards
- [ ] Check contact section: tinted cards and form
- [ ] Check navbar glassmorphism on scroll
- [ ] Verify dark theme is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)