### PR TITLE
fix(ci): replace removed Firebase CLI setup action

### DIFF
--- a/.github/workflows/firebase-functions-deploy.yml
+++ b/.github/workflows/firebase-functions-deploy.yml
@@ -37,10 +37,8 @@ jobs:
         with:
           credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_PRATICOS }}'
 
-      - name: Setup Firebase CLI
-        uses: FirebaseExtended/action-setup-firebase@v0
-        with:
-          version: latest
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
 
       - name: Deploy to Firebase Functions
         working-directory: firebase


### PR DESCRIPTION
## Summary
- Replace the removed `FirebaseExtended/action-setup-firebase@v0` GitHub Action with a direct `npm install -g firebase-tools`
- The `Deploy Firebase Functions` workflow has been broken since ~Feb 9 because the action repository was deleted from GitHub
- ADC auth from `google-github-actions/auth@v2` (already in the workflow) is auto-detected by the CLI — no other changes needed

## Test plan
- [ ] Trigger workflow via `workflow_dispatch` and verify all steps pass
- [ ] Alternatively, merge and push a trivial change in `firebase/functions/` to trigger the path-based trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)