### PR TITLE
feat: add i18n to public order tracking page

### DIFF
--- a/firebase/functions/src/routes/public/orders.routes.ts
+++ b/firebase/functions/src/routes/public/orders.routes.ts
@@ -97,6 +97,7 @@ router.get('/:token', shareTokenAuth, async (req: AuthenticatedRequest, res: Res
           phone: company.phone,
           email: company.email,
           address: company.address,
+          country: company.country,
         } : null,
         comments: comments.map((c) => ({
           // IDs removed for LGPD compliance

--- a/firebase/hosting/src/css/order-view.css
+++ b/firebase/hosting/src/css/order-view.css
@@ -1194,3 +1194,52 @@
 [data-theme="light"] .photo-item:hover {
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
 }
+
+/* ============================================
+   Language Switcher
+   ============================================ */
+.lang-switcher {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    display: flex;
+    gap: 6px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-full);
+    padding: 4px;
+    box-shadow: var(--shadow-lg);
+    z-index: 1000;
+}
+
+.lang-btn {
+    width: 36px;
+    height: 36px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--text-secondary);
+    font-family: var(--font-body);
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.lang-btn:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
+.lang-btn.active {
+    background: var(--color-primary);
+    color: white;
+}
+
+/* Position above toast */
+@supports (bottom: env(safe-area-inset-bottom)) {
+    .lang-switcher {
+        bottom: calc(24px + env(safe-area-inset-bottom));
+    }
+}

--- a/firebase/hosting/src/order/index.njk
+++ b/firebase/hosting/src/order/index.njk
@@ -11,6 +11,15 @@ layout: false
       document.documentElement.setAttribute('data-theme',t);
     })();
     </script>
+    <script>
+    (function(){
+      var p=new URLSearchParams(window.location.search).get('lang');
+      var n=(navigator.language||'pt').split('-')[0];
+      var l=(p&&['pt','en','es'].indexOf(p)!==-1)?p:(['pt','en','es'].indexOf(n)!==-1?n:'pt');
+      window.__orderLang=l;
+      document.documentElement.lang=l==='pt'?'pt-BR':l==='es'?'es-ES':'en-US';
+    })();
+    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Acompanhe sua OS - PraticOS</title>
@@ -29,7 +38,7 @@ layout: false
     <link rel="stylesheet" href="/style.css">
     <link rel="stylesheet" href="/css/order-view.css">
 
-    <!-- Open Graph -->
+    <!-- Open Graph (PT for crawlers — they don't execute JS) -->
     <meta property="og:title" content="Acompanhe sua OS - PraticOS">
     <meta property="og:description" content="Visualize detalhes, aprove orçamentos e deixe comentários">
     <meta property="og:type" content="website">
@@ -43,7 +52,7 @@ layout: false
         <!-- Loading State -->
         <div class="order-loading" id="loading-state">
             <div class="spinner"></div>
-            <p>Carregando...</p>
+            <p id="loading-text">Carregando...</p>
         </div>
 
         <!-- Error State -->
@@ -55,8 +64,8 @@ layout: false
                     <line x1="12" y1="16" x2="12.01" y2="16"/>
                 </svg>
             </div>
-            <h2>Link inválido</h2>
-            <p>Este link expirou ou é inválido. Por favor, solicite um novo link.</p>
+            <h2 id="error-title">Link inválido</h2>
+            <p id="error-message">Este link expirou ou é inválido. Por favor, solicite um novo link.</p>
         </div>
 
         <!-- Order Content -->


### PR DESCRIPTION
## Summary
- Add full i18n (pt/en/es) to the public order tracking page (`/q/{token}`)
- Early language detection via `?lang=xx` URL param with `navigator.language` fallback
- Floating language switcher (PT/EN/ES) for explicit language change
- Fix `formatCurrency()` to use company country instead of viewer locale (BR company always shows BRL)
- Expose `company.country` in the public orders API response
- Translate all hardcoded PT strings: labels, loading, error states, page title

## Test plan
- [ ] Access `/q/{token}` without param — detects browser language
- [ ] Access `/q/{token}?lang=en` — page in English
- [ ] Access `/q/{token}?lang=es` — page in Spanish
- [ ] Verify tab title, loading text, and error messages are translated
- [ ] Verify currency always matches company country (BRL for BR company even with `?lang=en`)
- [ ] Click language switcher buttons and verify page reloads in new language
- [ ] Approve/reject/comment in each language and verify translated toasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)