### PR TITLE
fix(bot): prevent vCard phone from replacing session {NUMERO}

### DIFF
--- a/backend/bot/workspace/AGENTS.md
+++ b/backend/bot/workspace/AGENTS.md
@@ -13,6 +13,7 @@ Nao peca permissao. Apenas faca.
 - Nunca exfiltre dados privados
 - Sem comandos destrutivos sem confirmar
 - Em grupos: dados do humano sao DELE, nao compartilhe
+- 🔴 {NUMERO} = origin.from da sessao. FIXO. Telefones de vCards, contatos compartilhados ou buscas sao DADOS, nunca {NUMERO}
 
 ---
 

--- a/backend/bot/workspace/SOUL.md
+++ b/backend/bot/workspace/SOUL.md
@@ -80,7 +80,7 @@ Criou OS→compartilhar? | Listou pendentes→atualizar? | Cadastrou cliente→a
 
 Dois niveis: **memory/MEMORY.md** (global) e **memory/users/{NUMERO}.md** (por usuario).
 
-**{NUMERO}:** normalizar origin.from com "+". Ex: "554884090709" → "+554884090709".
+**{NUMERO}:** normalizar origin.from com "+". Ex: "554884090709" → "+554884090709". Telefones de vCards/contatos = dados de cliente, NAO {NUMERO}.
 
 **Inicio de sessao:** ler `memory/users/{NUMERO}.md`. Se existir, usar dados salvos. Se NAO existir, chamar /bot/link/context e criar arquivo.
 
@@ -122,7 +122,7 @@ Responda quando mencionado ou pode adicionar valor. Fique em silêncio (HEARTBEA
 
 - Nunca invento dados — sempre consulto API
 - NOT_FOUND → releio SKILL.md. Max 3 tentativas.
-- 🔴 NUNCA invento {NUMERO}. Em cron: leio memoria p/ recuperar. Uso sessions_send, NUNCA message().
+- 🔴 {NUMERO} = origin.from. FIXO na sessao inteira. Telefones de vCards/contatos compartilhados sao DADOS DE CLIENTE, nunca {NUMERO}. Em cron: leio memoria p/ recuperar. Uso sessions_send, NUNCA message().
 - Dados sigilosos ficam sigilosos. Ações destrutivas só com confirmação.
 
 ---

--- a/backend/bot/workspace/skills/praticos/SKILL.md
+++ b/backend/bot/workspace/skills/praticos/SKILL.md
@@ -12,7 +12,11 @@ metadata: {"moltbot": {"always": true}}
 Env vars (ja configuradas): **$PRATICOS_API_URL** (base URL), **$PRATICOS_API_KEY** (auth key)
 **{NUMERO}** = origin.from da sessao (remetente). Normalizar: se nao comeca com "+", adicionar.
 
-🔴 NUNCA INVENTAR {NUMERO}. DEVE ser EXATAMENTE origin.from. Se nao souber, NAO faca chamadas.
+🔴 **IDENTIDADE vs DADOS — NUNCA CONFUNDIR:**
+- {NUMERO} = IDENTIDADE DA SESSAO. SEMPRE origin.from. IMUTAVEL.
+- Telefones em vCards, contatos compartilhados, resultados de busca = DADOS DE CLIENTE. NUNCA usar como {NUMERO}.
+- Se o usuario enviar um contato/vCard, o telefone dentro e do CLIENTE, NAO e origin.from.
+- NUNCA INVENTAR {NUMERO}. Se nao souber origin.from, NAO faca chamadas.
 
 **Numeros BR (+55):** WhatsApp usa +55{DDD}{8dig} (13 chars). Se API retornar 14 chars (+55489XXXXXXXX), remover o "9" apos DDD.
 
@@ -81,7 +85,7 @@ Boas-vindas: UMA frase curta com [userName]. Se houver OS pendentes (GET /bot/su
 ### REGRAS
 1. **IDs OBRIGATORIOS** — API NAO aceita nomes. Usar POST /bot/search/unified.
 2. **Criar OS:** busca unificada → exact? usar ID → suggestions? confirmar → nao encontrou? oferecer criar
-3. **CRUD:** buscar primeiro, confirmar editar/excluir. Criar CLIENTE: pedir contato WhatsApp (vCard).
+3. **CRUD:** buscar primeiro, confirmar editar/excluir. Criar CLIENTE: pedir contato WhatsApp (vCard). ⚠️ Telefone do vCard = dado do CLIENTE (campo `phone`). NUNCA usar como {NUMERO}.
 4. **Fotos:** multipart `-F "file=@/path"` (NAO base64)
 5. **Valores:** busca retorna `value`. Omitir = catalogo. Brinde = `"value":0`
 6. **Exibir OS:** ver CARD DE OS abaixo


### PR DESCRIPTION
## Summary

- Bot was using phone numbers from shared vCard contacts as `{NUMERO}` in API headers instead of `origin.from`, causing cross-tenant data access (e.g., message from +554899778842 triggered API call with +554891642529 from a shared contact)
- Previous fixes (a5dc9f7, e5b678a) failed because they were abstract ("never invent {NUMERO}") — the LLM didn't understand **why** other phone numbers appear in context
- Adds concrete "identity vs data" mental model across 5 defense layers in 3 files: AGENTS.md, SKILL.md (CONFIG + CRUD), SOUL.md (Memory + Limits)

## Test plan

- [ ] Deploy with `make sync` (config-only update, no rebuild)
- [ ] Send a vCard contact to the bot and verify in logs that `x-whatsapp-number` stays as the sender's `origin.from`
- [ ] Verify: `HEADERS: { "x-whatsapp-number": "+55..." }` always matches `Inbound message +55... →`
- [ ] Monitor logs for 24h post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)