### PR TITLE
feat(bot): add adaptive scheduling awareness to OS creation flow

### DIFF
--- a/backend/bot/workspace/SOUL.md
+++ b/backend/bot/workspace/SOUL.md
@@ -23,7 +23,7 @@ Objetivo, amigável (parceiro de trabalho), prestativo, natural no idioma do usu
 Frases curtas. Emojis com moderação. Formatação WhatsApp: *negrito* (UMA asterisco), _itálico_. Listas numeradas p/ opções.
 SEM textão, SEM markdown tables, SEM headers markdown.
 *negrito* abre e fecha na mesma linha. NAO colar: `*OS #10* do *cliente*` (OK) vs `*OS #10**cliente*` (ERRADO).
-Emojis padrão: 📋🔧👤💰🛠️📦✅⏳📅🔗. NAO inventar outros.
+Emojis padrão: 📋🔧👤💰🛠️📦✅⏳🗓️📅🔗. NAO inventar outros.
 
 ### Dados da API
 
@@ -68,7 +68,7 @@ Multilíngue. SEMPRE responder no idioma do usuario.
 ## Proatividade
 
 Após ação, sugiro 1 próximo passo (max 1, curta) no idioma do usuario:
-Criou OS→card+compartilhar? | Pendentes→atualizar? | Cadastrou cliente→abrir OS? | Checklist→concluir OS? | Adicionou item→card atualizado?
+Criou OS→card+compartilhar? | Pendentes→atualizar? | Cadastrou cliente→abrir OS? | Checklist→concluir OS? | Adicionou item→card atualizado? | Aprovou OS (sem agendamento)→agendar data?
 
 ## Memória
 
@@ -83,7 +83,7 @@ Dois níveis: **memory/MEMORY.md** (global) e **memory/users/{NUMERO}.md** (por 
 ```
 # {NUMERO}
 ## Perfil
-- **Nome:** [userName] | **VAK:** [detectar] | **Idioma:** [codigo] | **Prefere:** [obs]
+- **Nome:** [userName] | **VAK:** [detectar] | **Idioma:** [codigo] | **Agenda:** [sim/nao/?] | **Prefere:** [obs]
 ## Empresa & Segmento
 - **Empresa:** [companyName] | **Segmento:** [segment.name]
 ## Terminologia (segment.labels)

--- a/backend/bot/workspace/skills/praticos/SKILL.md
+++ b/backend/bot/workspace/skills/praticos/SKILL.md
@@ -74,7 +74,7 @@ message(filePath="/tmp/os-{NUM}.jpg", message="{card}")
 1. **IDs OBRIGATORIOS** — API NAO aceita nomes. Usar POST /bot/search/unified com ARRAYS para buscar tudo de uma vez:
    {"customer":"João","service":["tela","bateria"],"product":["película"]}
    🔴 NUNCA fazer multiplos /search/unified sequenciais. UMA chamada com todos os termos.
-2. **Criar OS:** busca (1 call com arrays) → IDs → POST /bot/orders/full.
+2. **Criar OS:** busca (1 call com arrays) → IDs → POST /bot/orders/full. Antes de finalizar, aplicar agendamento (regra 9).
    Apos criar → OS ativa. Adicionar item: se ha OS ativa, usar /services ou /products. So criar nova se pedido explicitamente.
 3. **CRUD:** buscar primeiro, confirmar editar/excluir. Criar CLIENTE: pedir contato WhatsApp (vCard). ⚠️ Telefone do vCard = dado do CLIENTE (campo `phone`). NUNCA usar como {NUMERO}.
 4. **Fotos:** upload multipart: `curl -s -X POST -H "X-API-Key: $PRATICOS_API_KEY" -H "X-WhatsApp-Number: {NUMERO}" -F "file=@/path/to/photo.jpg" "$PRATICOS_API_URL/bot/orders/{NUM}/photos/upload"`
@@ -99,6 +99,16 @@ message(filePath="/tmp/os-{NUM}.jpg", message="{card}")
      - "Instalacao split 12k sala" → usar "Instalacao de ar condicionado" + description "Split 12k - Sala"
    - 🔴 Info de etiquetas/dados tecnicos extraidos de fotos: NAO usar /comments. Anotar apenas no memory do usuario se necessario.
 6. 🔴 **DELETE = CONFIRMAR:** NUNCA executar DELETE sem antes informar O QUE será excluído e receber confirmação do usuario. Exceção: delete+re-add de serviço para atualizar valor (confirmar a alteração, não cada call).
+7. **Exibir OS:** ver CARD DE OS abaixo
+8. **Apos criar OS:** oferecer link → POST /bot/orders/{NUM}/share
+9. **Checklists:** `read(file_path="skills/praticos/references/checklists.md")`
+10. **Datas & Agendamento:** `scheduledDate` SEMPRE vai no POST /bot/orders/full. Comportamento depende do perfil do usuario (salvar em memoria campo **Agenda:** `sim` ou `nao`):
+    - **Perfil desconhecido (1as interacoes):** perguntar "Quer agendar pra quando?". Se informar data → `Agenda: sim`. Se recusar 2+ vezes → `Agenda: nao`.
+    - **Agenda: sim** → SEMPRE perguntar data/hora antes de criar. Se usuario informar → `scheduledDate` = ISO 8601. Se pular dessa vez → `scheduledDate` = data/hora atual.
+    - **Agenda: nao** (pronto atendimento) → NAO perguntar. `scheduledDate` = data/hora atual silenciosamente.
+    - Se usuario ja mencionou data na conversa, usar sem perguntar de novo (independente do perfil).
+    - `dueDate` = prazo de entrega, so incluir se usuario mencionar prazo espontaneamente.
+    - Converter linguagem natural: "amanha 14h" → calcular ISO; "segunda" → proxima segunda; "daqui 3 dias" → somar.
 
 ---
 

--- a/backend/bot/workspace/skills/praticos/references/api-endpoints.md
+++ b/backend/bot/workspace/skills/praticos/references/api-endpoints.md
@@ -34,7 +34,8 @@ POST /bot/orders/full
 Body: {customerId, deviceId?, deviceIds?:["id1","id2"], services:[{serviceId,value?,description?,deviceId?}], products:[{productId,quantity?,value?,description?,deviceId?}], dueDate?, scheduledDate?}
 `deviceIds` para multi-device. Se passado, ignora `deviceId`. Cada service/product pode ter `deviceId` para vincular ao dispositivo.
 Resposta: retorna `order` completo (mesmo formato de /details) + `formatContext` + `shareUrl` auto-criado. NAO precisa chamar GET /details apos criar.
-exec(command="curl -s -X POST -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" -H \"Content-Type: application/json\" -d '{\"customerId\":\"abc\",\"services\":[{\"serviceId\":\"srv1\",\"value\":350}]}' \"$PRATICOS_API_URL/bot/orders/full\"")
+exec(command="curl -s -X POST -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" -H \"Content-Type: application/json\" -d '{\"customerId\":\"abc\",\"services\":[{\"serviceId\":\"srv1\",\"value\":350}],\"scheduledDate\":\"2026-02-20T14:00:00.000Z\"}' \"$PRATICOS_API_URL/bot/orders/full\"")
+
 
 ## OS - Atualizar
 PATCH /bot/orders/{NUM} `{"status":"approved","dueDate":"2026-02-20T18:00:00.000Z","scheduledDate":"2026-02-20T09:00:00.000Z","assignedTo":"userId"}`

--- a/backend/bot/workspace/skills/praticos/references/os-card.md
+++ b/backend/bot/workspace/skills/praticos/references/os-card.md
@@ -48,14 +48,16 @@ Montar o texto a partir dos campos do `order`:
 🏷️ *Desconto:* {VALOR_FORMATADO}
 ✅ *Pago:* {VALOR_FORMATADO}
 ⏳ *A receber:* {VALOR_FORMATADO}
+🗓️ *Agendado:* {scheduledDate}
 📅 *Previsão:* {dueDate}
 
 🔗 *Link:* {shareUrl}
 ```
-**Labels:** Traduzir no idioma do usuario. Referência pt-BR: Cliente, Endereço, Serviços, Produtos, Total, Desconto, Pago, A receber, Previsão, Link. Ex en: Customer, Address, Services, Products, Total, Discount, Paid, Balance, Due date, Link.
+**Labels:** Traduzir no idioma do usuario. Referência pt-BR: Cliente, Endereço, Serviços, Produtos, Total, Desconto, Pago, A receber, Agendado, Previsão, Link. Ex en: Customer, Address, Services, Products, Total, Discount, Paid, Balance, Scheduled, Due date, Link.
 **Status:** Traduzir no idioma do usuario. Valores internos e referência pt-BR: quote=Orçamento | approved=Aprovado | progress=Em andamento | done=Concluído | canceled=Cancelado. Ex en: Quote | Approved | In progress | Completed | Canceled.
-**Omitir:** campos null, vazio ou com valor 0. Ex: paidAmount=0 → nao mostrar "Pago". discount=0 → nao mostrar "Desconto". address=null → nao mostrar "Endereço".
-**Moeda/Valores:** Usar `formatContext` retornado pelo endpoint `/bot/orders/{NUM}/details`. O `currency` define o simbolo (BRL=R$, EUR=€, USD=$) e o `locale` define o formato numerico: pt-BR → R$ 1.234,56 | en-US → $1,234.56 | fr-FR → 1 234,56 €. A API retorna valores raw (numeros).
+**Omitir:** campos null, vazio ou com valor 0. Ex: paidAmount=0 → nao mostrar "Pago". discount=0 → nao mostrar "Desconto". address=null → nao mostrar "Endereço". scheduledDate=null → nao mostrar "Agendado".
+**Moeda/Valores:** Usar `formatContext` retornado pelo endpoint. O `currency` define o simbolo (BRL=R$, EUR=€, USD=$) e o `locale` define o formato numerico: pt-BR → R$ 1.234,56 | en-US → $1,234.56 | fr-FR → 1 234,56 €. A API retorna valores raw (numeros).
+**Datas:** formato BR dia/mes/ano + hora. Ex: 20/02/2026 09:00 — NUNCA ISO 8601 no card. Se hora for 00:00, mostrar so data.
 **remaining** = total - discount - paidAmount.
 **Multi-device:** Usar `deviceCount` da resposta de /details. Se `deviceCount > 1`, listar todos os devices numerados e agrupar serviços/produtos por `deviceId`. Itens sem `deviceId` ficam em "Geral" (traduzir). O label plural do device vem de `segment.labels` (ex: "Veículos", "Aparelhos"). Se nao houver, usar "Dispositivos"/"Devices"/etc.
 


### PR DESCRIPTION
## Summary
- Bot now collects `scheduledDate` during OS creation with adaptive behavior
- Learns user profile: **Agenda: sim** (scheduling businesses) vs **Agenda: nao** (walk-in/pronto atendimento)
- `scheduledDate` always populated — user-provided date or current date/time as default
- OS card displays `🗓️ *Agendado:*` with BR date format

## Changes
- **SKILL.md**: Rule 2 references scheduling; new rule 9 with full adaptive logic
- **SOUL.md**: Proactivity chain for approval→scheduling, `🗓️` emoji, `Agenda` field in user memory
- **os-card.md**: `scheduledDate` line + date formatting rule (BR format, never ISO)
- **api-endpoints.md**: POST `/bot/orders/full` example includes `scheduledDate`

## Test plan
- [ ] Create OS with a scheduling user — bot asks for date
- [ ] Create OS with a walk-in user — bot uses current date silently
- [ ] Verify card displays `🗓️ Agendado` with BR format
- [ ] Verify card omits `🗓️ Agendado` when scheduledDate is null
- [ ] Approve OS without scheduling — bot suggests scheduling
- [ ] Mention date naturally in message — bot uses it without asking again

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)