### PR TITLE
fix(functions): exclude test files from tsc build

### DIFF
--- a/firebase/functions/tsconfig.json
+++ b/firebase/functions/tsconfig.json
@@ -19,6 +19,8 @@
     "src/**/*"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/__tests__"
   ]
 }


### PR DESCRIPTION
## Summary
- Excludes `*.test.ts` and `__tests__/` directories from the TypeScript production build
- Fixes `firebase deploy --only functions` failing with TS2742 error on test helpers

## Test plan
- [x] `npm run build` passes cleanly
- [x] `npx jest --verbose` — 73 tests passing
- [x] No test files in `lib/` output directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)