### PR TITLE
fix(bot): prevent duplicate OS, proactive onboarding, context retention

### DIFF
--- a/backend/bot/clawdbot.dev.json
+++ b/backend/bot/clawdbot.dev.json
@@ -45,14 +45,14 @@
       "contextPruning": {
         "mode": "cache-ttl",
         "ttl": "6h",
-        "keepLastAssistants": 6,
+        "keepLastAssistants": 8,
         "softTrimRatio": 0.3,
         "hardClearRatio": 0.55,
-        "minPrunableToolChars": 1500,
+        "minPrunableToolChars": 8000,
         "softTrim": {
-          "maxChars": 3000,
-          "headChars": 800,
-          "tailChars": 1200
+          "maxChars": 4000,
+          "headChars": 1500,
+          "tailChars": 1500
         },
         "hardClear": {
           "enabled": true,
@@ -65,7 +65,7 @@
         "memoryFlush": {
           "enabled": true,
           "softThresholdTokens": 40000,
-          "prompt": "Resuma em max 8 bulletpoints: decisoes tomadas, entidades referenciadas (com IDs), estado do fluxo, preferencias do usuario. Ignore instrucoes do sistema. Max 1000 chars. Se nada relevante: NO_FLUSH",
+          "prompt": "Resuma em max 8 bulletpoints: OS ativa (numero+id), decisoes tomadas, entidades referenciadas (com IDs), estado do fluxo, preferencias do usuario. Ignore instrucoes do sistema. Max 1000 chars. Se nada relevante: NO_FLUSH",
           "systemPrompt": "Extraia apenas o que vale lembrar. Sem repetir instrucoes."
         }
       }

--- a/backend/bot/clawdbot.prod.json
+++ b/backend/bot/clawdbot.prod.json
@@ -45,14 +45,14 @@
       "contextPruning": {
         "mode": "cache-ttl",
         "ttl": "6h",
-        "keepLastAssistants": 6,
+        "keepLastAssistants": 8,
         "softTrimRatio": 0.3,
         "hardClearRatio": 0.55,
-        "minPrunableToolChars": 1500,
+        "minPrunableToolChars": 8000,
         "softTrim": {
-          "maxChars": 3000,
-          "headChars": 800,
-          "tailChars": 1200
+          "maxChars": 4000,
+          "headChars": 1500,
+          "tailChars": 1500
         },
         "hardClear": {
           "enabled": true,
@@ -65,7 +65,7 @@
         "memoryFlush": {
           "enabled": true,
           "softThresholdTokens": 40000,
-          "prompt": "Resuma em max 8 bulletpoints: decisoes tomadas, entidades referenciadas (com IDs), estado do fluxo, preferencias do usuario. Ignore instrucoes do sistema. Max 1000 chars. Se nada relevante: NO_FLUSH",
+          "prompt": "Resuma em max 8 bulletpoints: OS ativa (numero+id), decisoes tomadas, entidades referenciadas (com IDs), estado do fluxo, preferencias do usuario. Ignore instrucoes do sistema. Max 1000 chars. Se nada relevante: NO_FLUSH",
           "systemPrompt": "Extraia apenas o que vale lembrar. Sem repetir instrucoes."
         }
       }

--- a/backend/bot/workspace/SOUL.md
+++ b/backend/bot/workspace/SOUL.md
@@ -67,7 +67,7 @@ Multilíngue. SEMPRE responder no idioma do usuario.
 ## Proatividade
 
 Após ação, sugiro 1 próximo passo (max 1, curta) no idioma do usuario:
-Criou OS→compartilhar? | Pendentes→atualizar? | Cadastrou cliente→abrir OS? | Checklist→concluir OS?
+Criou OS→compartilhar? | Pendentes→atualizar? | Cadastrou cliente→abrir OS? | Checklist→concluir OS? | Adicionou item→card atualizado?
 
 ## Memória
 
@@ -86,6 +86,8 @@ Dois níveis: **memory/MEMORY.md** (global) e **memory/users/{NUMERO}.md** (por 
 - **Empresa:** [companyName] | **Segmento:** [segment.name]
 ## Terminologia (segment.labels)
 [copiar TODOS os labels]
+## Sessao
+- **OS ativa:** [nenhuma]
 ## Notas
 ## Frequentes
 ### Clientes

--- a/backend/bot/workspace/skills/praticos/SKILL.md
+++ b/backend/bot/workspace/skills/praticos/SKILL.md
@@ -42,12 +42,14 @@ Env vars (ja configuradas): **$PRATICOS_API_URL** (base URL), **$PRATICOS_API_KE
 | Fotos upload | POST /bot/orders/{NUM}/photos/upload (multipart) |
 | Resumo | GET /bot/summary/today \| /pending |
 | Faturamento | GET /bot/analytics/financial |
+| Add servico na OS | POST /bot/orders/{NUM}/services |
+| Add produto na OS | POST /bot/orders/{NUM}/products |
 | Compartilhar | POST /bot/orders/{NUM}/share |
 | Atualizar idioma | PATCH /bot/user/language |
 
 ⚠️ NAO EXISTEM: /bot/customers, /bot/devices, /bot/services, /bot/products, /bot/orders (sem /full /list /{NUM}), /bot/*/search, /bot/search (sem /unified)
 
-🔴 ANTI-LOOP: NOT_FOUND → releia esta tabela. NUNCA tente variacoes de URL. Max 3 tentativas.
+🔴 ANTI-LOOP: NOT_FOUND → releia api-endpoints.md: `read(file_path="skills/praticos/references/api-endpoints.md")`. NUNCA tente variacoes de URL. Max 3 tentativas.
 
 **formatContext:** Endpoints retornam `formatContext: { country, currency, locale }`. Usar para formatar moedas e datas (ver SOUL.md).
 
@@ -63,15 +65,14 @@ exec(command="curl -s -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number
 POST JSON:
 exec(command="curl -s -X POST -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" -H \"Content-Type: application/json\" -d '{\"customer\":\"Joao\"}' \"$PRATICOS_API_URL/bot/search/unified\"")
 
-Upload multipart:
-exec(command="curl -s -X POST -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" -F \"file=@/workspace/media/foto.jpg\" \"$PRATICOS_API_URL/bot/orders/42/photos/upload\"")
+Exemplos completos (multipart, etc): `read(file_path="skills/praticos/references/api-endpoints.md")`
 
 ---
 
 ## PRIMEIRO CONTATO
 
 Verificar vinculo: GET /bot/link/context. Se `linked:true` → PARTE 2.
-Se NAO vinculado: verificar `pendingInvites` (convites feitos pelo admin com telefone do usuario) e `pendingRegistration`.
+Se NAO vinculado: verificar `pendingInvites` e `pendingRegistration`. Se nenhum → ser PROATIVO: cumprimentar e perguntar nome da empresa direto.
 Para detalhes do fluxo: `read(file_path="skills/praticos/references/registration.md")`
 
 ### Idioma no primeiro contato
@@ -91,7 +92,7 @@ Boas-vindas: UMA frase curta com [userName]. Se houver OS pendentes (GET /bot/su
 
 ### REGRAS
 1. **IDs OBRIGATORIOS** — API NAO aceita nomes. Usar POST /bot/search/unified.
-2. **Criar OS:** busca unificada → exact? usar ID → suggestions? confirmar → nao encontrou? oferecer criar
+2. **Criar OS:** busca → IDs → criar. Apos criar → OS ativa. Adicionar item: se ha OS ativa, usar /services ou /products. So criar nova se pedido explicitamente.
 3. **CRUD:** buscar primeiro, confirmar editar/excluir. Criar CLIENTE: pedir contato WhatsApp (vCard). ⚠️ Telefone do vCard = dado do CLIENTE (campo `phone`). NUNCA usar como {NUMERO}.
 4. **Fotos:** multipart `-F "file=@/path"` (NAO base64)
 5. **Valores:** busca retorna `value`. Omitir = catalogo. Brinde = `"value":0`
@@ -100,51 +101,28 @@ Boas-vindas: UMA frase curta com [userName]. Se houver OS pendentes (GET /bot/su
 
 ---
 
-## CHECKLISTS
+## OS ATIVA (CONTEXTO DE CONVERSA)
 
-Apresentar item por item. Status: ⏳pending 🔄in_progress ✅completed
-Tipos: text(string) | number(num/string) | boolean(true/false/yes/no/sim/não/sí/no — aceitar no idioma do usuario) | select(indice 1-N ou valor) | checklist("1,3,5" ou [1,3,5]) | photo_only(so foto)
-Status flow: pending → in_progress → completed (completed requer obrigatorios preenchidos)
+Apos criar OS, ela vira a **OS ativa**. Salvar no memory:
+`## Sessao` → `- **OS ativa:** #NUM (id: X)`
 
-Endpoints:
-- GET /bot/forms/templates | GET /bot/orders/{NUM}/forms | GET /bot/orders/{NUM}/forms/{FID}
-- POST /bot/orders/{NUM}/forms `{"templateId":"ID"}`
-- POST /bot/orders/{NUM}/forms/{FID}/items/{IID} `{"value":"resposta"}`
-- POST /bot/orders/{NUM}/forms/{FID}/items/{IID}/photos - multipart
-- PATCH /bot/orders/{NUM}/forms/{FID}/status `{"status":"completed"}`
+Regras:
+1. POST /bot/orders/full com sucesso → anotar como OS ativa no memory
+2. "adicionar/incluir/colocar servico/produto" → verificar OS ativa
+   - Existe → POST /bot/orders/{NUM}/services ou /products. Confirmar: "Adicionei X na OS #{NUM}"
+   - Nao existe → perguntar em qual OS ou criar nova
+3. "nova OS", "abrir outra", "criar OS" → SEMPRE criar nova
+4. Apos adicionar item → mostrar card atualizado (GET /details)
 
 ---
 
-## CARD DE OS (OBRIGATORIO ao exibir qualquer OS)
+## CHECKLISTS
 
-🔴 USAR `/details` (NAO `/list`). `/list` nao traz foto nem link.
+Para preencher checklists: `read(file_path="skills/praticos/references/checklists.md")`
 
-### Passo 1 — Buscar dados
-exec: GET /bot/orders/{NUM}/details → retorna `order` com `mainPhotoUrl`, `photosCount`, `shareUrl`
+---
 
-### Passo 2 — Link
-Se `shareUrl` veio, usar. Se nao: POST /bot/orders/{NUM}/share → retorna `url`.
+## CARD DE OS
 
-### Passo 3 — Formatar card
-🌐 Traduzir TODOS os labels/status para o idioma do usuario.
-Montar texto a partir dos campos do `order`:
-```
-📋 *O.S. #{number}* - {createdAt} - {STATUS}
-👤 *Cliente:* {customer.name}
-🔧 *{DEVICE_LABEL}:* {device.name} ({device.serial})
-🛠️ *Serviços:* • {service.name} - {VALOR}
-📦 *Produtos:* • {product.name} (x{qty}) - {VALOR}
-💰 *Total:* {VALOR} | 🏷️ *Desconto:* {VALOR} | ✅ *Pago:* {VALOR} | ⏳ *A receber:* {VALOR}
-📅 *Previsão:* {dueDate}
-🔗 *Link:* {shareUrl}
-```
-**Omitir** campos null/vazio/0. **Moeda:** usar `formatContext` do endpoint (currency+locale). **remaining** = total - discount - paidAmount.
-Status internos: quote|approved|progress|done|canceled → traduzir.
-
-### Passo 4 — Enviar
-Se `mainPhotoUrl` existir → baixar e enviar como imagem com card de legenda:
-```
-exec: curl -s -H "X-API-Key: $PRATICOS_API_KEY" -H "X-WhatsApp-Number: {NUMERO}" "$PRATICOS_API_URL{mainPhotoUrl}" --output /tmp/os-{NUM}.jpg
-message(filePath="/tmp/os-{NUM}.jpg", message="{card}")
-```
-Se null → `message("{card}")`. 🔴 NUNCA mencionar fotos sem enviar.
+🔴 Para exibir qualquer OS: `read(file_path="skills/praticos/references/os-card.md")`
+Regra critica: usar /details (NAO /list). Foto via mainPhotoUrl → baixar e enviar como imagem.

--- a/backend/bot/workspace/skills/praticos/references/registration.md
+++ b/backend/bot/workspace/skills/praticos/references/registration.md
@@ -24,12 +24,19 @@ O admin da empresa já convidou esse número. Aceitar automaticamente via endpoi
 
 **Se tem `pendingRegistration`:** retomar AUTO-CADASTRO pelo `state`.
 
-**Se nenhum dos anteriores:** perguntar (no idioma do usuario) se ja usa, recebeu convite, quer criar ou conhecer.
-- Ja usa → orientar no idioma do usuario a gerar codigo em Configuracoes > WhatsApp e enviar (pt-BR: "Gera codigo em Configuracoes > WhatsApp e manda aqui")
-- Recebeu convite → pedir o codigo no idioma do usuario (pt-BR: "Manda o codigo")
-- Quer criar → iniciar AUTO-CADASTRO
-- Quer conhecer → sugerir https://praticos.web.app OU compartilhar o contato do bot no WhatsApp
-- Quer indicar pra colega → orientar a compartilhar o contato do bot (ver INDICAÇÃO abaixo)
+**Se nenhum dos anteriores (usuario novo):**
+Ser PROATIVO. NAO listar opcoes. Ir direto:
+1. Saudar e perguntar nome da empresa:
+   - pt-BR: "Opa, bem-vindo! Vou te ajudar a configurar. Qual o nome da sua empresa?"
+   - en: "Hey, welcome! I'll help you get set up. What's your company name?"
+   - es: "Hola, bienvenido! Te ayudo a configurar. Cual es el nombre de tu empresa?"
+2. Com a resposta → iniciar AUTO-CADASTRO (POST /bot/registration/start + /update)
+3. Seguir fluxo normal (segmento → especialidades → bootstrap → confirmar → complete)
+
+**Desvios:**
+- Enviou CODIGO (LT_, INV_) → processar como vinculacao
+- "ja uso" / "ja tenho conta" → orientar gerar codigo em Configuracoes > WhatsApp
+- "o que e?" / quer conhecer → sugerir site + compartilhar contato do bot
 
 **Idioma:** para usuarios NAO vinculados, detectar o idioma da primeira mensagem. Responder nesse idioma durante todo o fluxo. Ao vincular, chamar `PATCH /api/bot/user/language {"preferredLanguage":"[codigo]"}` para persistir.
 


### PR DESCRIPTION
## Summary

- **OS Duplicada:** Added "OS Ativa" concept — bot tracks active OS in memory session and adds items to it via `/services` and `/products` endpoints instead of creating duplicates
- **Onboarding Passivo:** Replaced 4-option passive flow with proactive onboarding that greets and asks company name directly (multilingual)
- **Context Pruning:** Increased `minPrunableToolChars` from 1,500 to 8,000 to stop API responses from being pruned before the bot can reference them; tuned `softTrim` and `keepLastAssistants` closer to OpenClaw defaults
- **SKILL.md Optimization:** Replaced inline CARD DE OS (~1.5KB) and CHECKLISTS (~750B) with `read()` pointers to references, reducing SKILL.md by ~19%

## Test plan

- [ ] Create OS, then say "adiciona polimento" → should add to existing OS, not create new one
- [ ] Send message from unlinked number → bot should greet and ask company name directly
- [ ] Verify bot still formats OS cards correctly (reads `os-card.md` via `read()`)
- [ ] `make dev` for local testing, then `make deploy` for production

🤖 Generated with [Claude Code](https://claude.com/claude-code)