### PR TITLE
revert(bot): revert workspace/skill changes from #164

### DIFF
--- a/backend/bot/workspace/SOUL.md
+++ b/backend/bot/workspace/SOUL.md
@@ -67,7 +67,7 @@ Multilíngue. SEMPRE responder no idioma do usuario.
 ## Proatividade
 
 Após ação, sugiro 1 próximo passo (max 1, curta) no idioma do usuario:
-Criou OS→compartilhar? | Pendentes→atualizar? | Cadastrou cliente→abrir OS? | Checklist→concluir OS? | Adicionou item→card atualizado?
+Criou OS→compartilhar? | Pendentes→atualizar? | Cadastrou cliente→abrir OS? | Checklist→concluir OS?
 
 ## Memória
 
@@ -86,8 +86,6 @@ Dois níveis: **memory/MEMORY.md** (global) e **memory/users/{NUMERO}.md** (por 
 - **Empresa:** [companyName] | **Segmento:** [segment.name]
 ## Terminologia (segment.labels)
 [copiar TODOS os labels]
-## Sessao
-- **OS ativa:** [nenhuma]
 ## Notas
 ## Frequentes
 ### Clientes

--- a/backend/bot/workspace/skills/praticos/references/registration.md
+++ b/backend/bot/workspace/skills/praticos/references/registration.md
@@ -24,19 +24,12 @@ O admin da empresa já convidou esse número. Aceitar automaticamente via endpoi
 
 **Se tem `pendingRegistration`:** retomar AUTO-CADASTRO pelo `state`.
 
-**Se nenhum dos anteriores (usuario novo):**
-Ser PROATIVO. NAO listar opcoes. Ir direto:
-1. Saudar e perguntar nome da empresa:
-   - pt-BR: "Opa, bem-vindo! Vou te ajudar a configurar. Qual o nome da sua empresa?"
-   - en: "Hey, welcome! I'll help you get set up. What's your company name?"
-   - es: "Hola, bienvenido! Te ayudo a configurar. Cual es el nombre de tu empresa?"
-2. Com a resposta → iniciar AUTO-CADASTRO (POST /bot/registration/start + /update)
-3. Seguir fluxo normal (segmento → especialidades → bootstrap → confirmar → complete)
-
-**Desvios:**
-- Enviou CODIGO (LT_, INV_) → processar como vinculacao
-- "ja uso" / "ja tenho conta" → orientar gerar codigo em Configuracoes > WhatsApp
-- "o que e?" / quer conhecer → sugerir site + compartilhar contato do bot
+**Se nenhum dos anteriores:** perguntar (no idioma do usuario) se ja usa, recebeu convite, quer criar ou conhecer.
+- Ja usa → orientar no idioma do usuario a gerar codigo em Configuracoes > WhatsApp e enviar (pt-BR: "Gera codigo em Configuracoes > WhatsApp e manda aqui")
+- Recebeu convite → pedir o codigo no idioma do usuario (pt-BR: "Manda o codigo")
+- Quer criar → iniciar AUTO-CADASTRO
+- Quer conhecer → sugerir https://praticos.web.app OU compartilhar o contato do bot no WhatsApp
+- Quer indicar pra colega → orientar a compartilhar o contato do bot (ver INDICAÇÃO abaixo)
 
 **Idioma:** para usuarios NAO vinculados, detectar o idioma da primeira mensagem. Responder nesse idioma durante todo o fluxo. Ao vincular, chamar `PATCH /api/bot/user/language {"preferredLanguage":"[codigo]"}` para persistir.
 


### PR DESCRIPTION
## Summary

- Reverts SKILL.md, SOUL.md and registration.md to pre-#164 state
- The PR #164 was intended to only ship config tuning (`clawdbot.prod.json` / `clawdbot.dev.json`), but the merge commit included workspace changes that weren't ready

## Files reverted

- `backend/bot/workspace/SOUL.md` — remove Sessao template and proatividade addition
- `backend/bot/workspace/skills/praticos/SKILL.md` — restore original CHECKLISTS, CARD DE OS, API section, REGRAS
- `backend/bot/workspace/skills/praticos/references/registration.md` — restore original onboarding flow

## Config changes from #164 (kept, not affected)

- `clawdbot.prod.json` / `clawdbot.dev.json` — `minPrunableToolChars` 1500→8000, `keepLastAssistants` 6→8, softTrim tuning, memoryFlush with "OS ativa"

🤖 Generated with [Claude Code](https://claude.com/claude-code)