### PR TITLE
fix(bot): improve customer search and slim orders response

### DIFF
--- a/firebase/functions/src/models/types.ts
+++ b/firebase/functions/src/models/types.ts
@@ -119,6 +119,7 @@ export interface CustomerAggr {
 
 export interface Customer extends CustomerAggr {
   address?: string;
+  keywords?: string[];
   company: CompanyAggr;
   createdAt: DateValue;
   createdBy: UserAggr;

--- a/firebase/functions/src/routes/bot/orders.routes.ts
+++ b/firebase/functions/src/routes/bot/orders.routes.ts
@@ -44,11 +44,18 @@ router.get('/list', async (req: AuthenticatedRequest, res: Response) => {
       offset: 0,
     });
 
-    // Strip heavy fields (photos, transactions) to save tokens in list view
-    // Bot should use GET /bot/orders/{NUM}/details for full order data + photo
-    const lightOrders = result.data.map(({ photos, transactions, ...rest }) => ({
-      ...rest,
-      photosCount: photos?.length || 0,
+    // Allowlist: only fields the bot needs — saves ~75% tokens vs spreading everything
+    // Bot should use GET /bot/orders/{NUM}/details for full order data + photos
+    const lightOrders = result.data.map(order => ({
+      number: order.number,
+      status: order.status,
+      customer: order.customer ? { name: order.customer.name } : null,
+      device: order.device ? { name: order.device.name, serial: order.device.serial } : null,
+      total: order.total,
+      dueDate: order.dueDate,
+      scheduledDate: order.scheduledDate,
+      createdAt: order.createdAt,
+      photosCount: order.photos?.length || 0,
     }));
 
     res.json({


### PR DESCRIPTION
## Summary

- **Slim `/bot/orders/list` response**: Replace spread-and-exclude with explicit allowlist (number, status, customer.name, device, total, dates, photosCount). Reduces ~3500 chars → ~900 chars per response (-75% tokens)
- **Add prefix query fallback**: After keyword search returns empty, query `nameLower` with Firestore range prefix — works for ALL customers including those created via Flutter app (without `keywords` field)
- **Lazy keyword backfill**: When prefix or memory fallback finds customers missing `keywords`, generates and saves them fire-and-forget so future searches use the fast keyword path
- **Phone digits fallback**: `findCustomerByPhone` now falls back to searching last 8 digits in `keywords` array when exact match fails
- **Increase memory fallback limit**: 100 → 500 records for broader substring matching

### Root cause

Bot (Gemini Flash) sends `{"query": "Kharine Arendt"}` → keyword search finds nothing because Flutter-created customers lack `keywords` field → memory fallback only loads 100 records → returns empty → bot creates duplicates.

### Search order after fix

```
1. Keywords array-contains (fast, customers with keywords)
   ↓ empty
2. Prefix query on nameLower (fast, works for ALL records)
   ↓ empty
3. Memory fallback (500 records, substring match) + auto-backfill keywords
```

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Search "Kharine" → finds via prefix on `nameLower`
- [ ] Search by phone "+393334287139" → finds via digits fallback
- [ ] `GET /bot/orders/list` → response is slim (~200 chars/OS, no shareLink/company/rating)
- [ ] After search finds customer without keywords → verify keywords get backfilled in Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)