### PR TITLE
fix(ads): enable Firebase Analytics iOS + SKAdNetwork

### DIFF
--- a/docs/ADS_CAMPAIGNS.md
+++ b/docs/ADS_CAMPAIGNS.md
@@ -266,10 +266,23 @@
 ### Prioridade Baixa
 
 - [x] **Meta Ads - Token de longa duração**: Token de 60 dias gerado e salvo em `~/.meta-ads.yaml` (23/02/2026).
-- [ ] **GoogleService-Info.plist**: Os flags `IS_ANALYTICS_ENABLED` e `IS_ADS_ENABLED` estão `false` no iOS. Embora o Analytics funcione via SDK, considerar atualizar para `true` em uma futura release.
+- [x] **GoogleService-Info.plist**: `IS_ANALYTICS_ENABLED` e `IS_ADS_ENABLED` alterados para `true`. SKAdNetwork IDs (Google Ads + Meta) e `NSUserTrackingUsageDescription` adicionados aos Info plists. Concluído em 24/02/2026.
+- [ ] **iOS - ATT Prompt**: Implementar diálogo App Tracking Transparency com package `app_tracking_transparency`. Pré-requisito: `NSUserTrackingUsageDescription` já adicionado ao plist.
 - [ ] **Google Ads - Otimização contínua**: Depois de 2 semanas de dados, analisar termos de busca, pausar keywords ruins, ajustar bids.
 
 ## Histórico de Alterações
+
+### 24/02/2026 (Firebase Analytics iOS + SKAdNetwork)
+- Habilitou `IS_ANALYTICS_ENABLED` e `IS_ADS_ENABLED` no `GoogleService-Info.plist`
+  - Permite Firebase Analytics enviar eventos iOS ao GA4
+  - Pré-requisito para Google Ads criar conversion action `FIREBASE_IOS_FIRST_OPEN`
+- Adicionou **SKAdNetwork IDs** em `Info-Debug.plist` e `Info-Release.plist`:
+  - `cstr6suwn9.skadnetwork` (Google Ads)
+  - `v9wttpbfkn.skadnetwork` (Meta/Facebook)
+  - `n38lu8286q.skadnetwork` (Meta/Facebook)
+- Adicionou `NSUserTrackingUsageDescription` nos Info plists
+  - Pré-requisito para ATT prompt (código Dart necessário em PR separado)
+- Motivação: campanha App-iOS (ID: 23598117814) com 1 impressão e 0 conversões desde criação
 
 ### 23/02/2026 (Campanha App-iOS - Google Ads)
 - Criada campanha **App-iOS** (ID: 23598117814) via Google Ads API

--- a/ios/Runner/Info-Debug.plist
+++ b/ios/Runner/Info-Debug.plist
@@ -80,6 +80,25 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>SKAdNetworkItems</key>
+	<array>
+		<!-- Google Ads -->
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>cstr6suwn9.skadnetwork</string>
+		</dict>
+		<!-- Meta/Facebook -->
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>v9wttpbfkn.skadnetwork</string>
+		</dict>
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>n38lu8286q.skadnetwork</string>
+		</dict>
+	</array>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>O PraticOS utiliza este identificador para medir a eficácia de campanhas publicitárias e melhorar sua experiência.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/ios/Runner/Info-Release.plist
+++ b/ios/Runner/Info-Release.plist
@@ -78,6 +78,25 @@
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>SKAdNetworkItems</key>
+	<array>
+		<!-- Google Ads -->
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>cstr6suwn9.skadnetwork</string>
+		</dict>
+		<!-- Meta/Facebook -->
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>v9wttpbfkn.skadnetwork</string>
+		</dict>
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>n38lu8286q.skadnetwork</string>
+		</dict>
+	</array>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>O PraticOS utiliza este identificador para medir a eficácia de campanhas publicitárias e melhorar sua experiência.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>


### PR DESCRIPTION
## Summary
- Enable Firebase Analytics and Ads flags in `GoogleService-Info.plist` (`IS_ANALYTICS_ENABLED` + `IS_ADS_ENABLED` → `true`)
- Add SKAdNetwork IDs for Google Ads (`cstr6suwn9`) and Meta (`v9wttpbfkn`, `n38lu8286q`) to both Info-Debug.plist and Info-Release.plist
- Add `NSUserTrackingUsageDescription` as prerequisite for future ATT prompt implementation

## Context
The App-iOS campaign (Google Ads ID: 23598117814) shows 1 impression and 0 conversions since creation. Root cause: Firebase Analytics was disabled in the iOS plist, preventing GA4 from receiving iOS events. Without data, Google Ads cannot create the `FIREBASE_IOS_FIRST_OPEN` conversion action and the `MAXIMIZE_CONVERSIONS` bidding cannot learn.

## What's NOT included (separate PRs)
- ATT prompt Dart code (`app_tracking_transparency` package)
- Custom analytics events
- Android AD_ID permission changes

## Test plan
- [ ] Verify `IS_ANALYTICS_ENABLED` and `IS_ADS_ENABLED` are `true` in local GoogleService-Info.plist
- [ ] Verify SKAdNetwork IDs present in both Info plists
- [ ] Verify `NSUserTrackingUsageDescription` present in both Info plists
- [ ] After merge + TestFlight deploy: check Firebase Console for iOS events
- [ ] After 24-48h: check if `FIREBASE_IOS_FIRST_OPEN` appears in Google Ads conversion actions
- [ ] **Important**: Update CI/CD's `GoogleService-Info.plist` copy to set flags to `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)