### PR TITLE
fix(bot): show OS card after creation

### DIFF
--- a/backend/bot/workspace/SOUL.md
+++ b/backend/bot/workspace/SOUL.md
@@ -67,7 +67,7 @@ Multilíngue. SEMPRE responder no idioma do usuario.
 ## Proatividade
 
 Após ação, sugiro 1 próximo passo (max 1, curta) no idioma do usuario:
-Criou OS→compartilhar? | Pendentes→atualizar? | Cadastrou cliente→abrir OS? | Checklist→concluir OS? | Adicionou item→card atualizado?
+Criou OS→card+compartilhar? | Pendentes→atualizar? | Cadastrou cliente→abrir OS? | Checklist→concluir OS? | Adicionou item→card atualizado?
 
 ## Memória
 

--- a/backend/bot/workspace/skills/praticos/SKILL.md
+++ b/backend/bot/workspace/skills/praticos/SKILL.md
@@ -97,7 +97,7 @@ Boas-vindas: UMA frase curta com [userName]. Se houver OS pendentes (GET /bot/su
 4. **Fotos:** multipart `-F "file=@/path"` (NAO base64)
 5. **Valores:** busca retorna `value`. Omitir = catalogo. Brinde = `"value":0`
 6. **Exibir OS:** ver CARD DE OS abaixo
-7. **Apos criar OS:** oferecer link → POST /bot/orders/{NUM}/share
+7. 🔴 **Apos criar OS:** SEMPRE exibir card (GET /details → formato CARD DE OS abaixo) + oferecer compartilhar → POST /bot/orders/{NUM}/share
 
 ---
 
@@ -107,7 +107,7 @@ Apos criar OS, ela vira a **OS ativa**. Salvar no memory:
 `## Sessao` → `- **OS ativa:** #NUM (id: X)`
 
 Regras:
-1. POST /bot/orders/full com sucesso → anotar como OS ativa no memory
+1. POST /bot/orders/full com sucesso → anotar como OS ativa no memory → exibir card (GET /bot/orders/{NUM}/details → formato CARD DE OS)
 2. "adicionar/incluir/colocar servico/produto" → verificar OS ativa
    - Existe → POST /bot/orders/{NUM}/services ou /products. Confirmar: "Adicionei X na OS #{NUM}"
    - Nao existe → perguntar em qual OS ou criar nova


### PR DESCRIPTION
## Summary
- After creating an OS, the bot now displays the formatted OS card (via GET /details) before offering to share the link
- Previously the bot responded with plain text (e.g. "Tudo certinho e aprovado na OS #11444") instead of the rich card format
- Added redundant instructions in both SKILL.md rule 7 and OS ATIVA rule 1 to survive context pruning

## Deploy
```bash
cd backend/bot
make sync    # Updates configs/skills without rebuild
```

## Test plan
- [ ] Send a message to the bot asking to create an OS
- [ ] Verify the bot displays the formatted card (with emojis, fields, values) after creation
- [ ] Verify the bot offers to share the link after showing the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)