### PR TITLE
feat(bot): add comment endpoints for orders

### DIFF
--- a/backend/bot/workspace/skills/praticos/SKILL.md
+++ b/backend/bot/workspace/skills/praticos/SKILL.md
@@ -45,6 +45,8 @@ Env vars (ja configuradas): **$PRATICOS_API_URL** (base URL), **$PRATICOS_API_KE
 | Add servico na OS | POST /bot/orders/{NUM}/services |
 | Add produto na OS | POST /bot/orders/{NUM}/products |
 | Compartilhar | POST /bot/orders/{NUM}/share |
+| Comentar/Anotar | POST /bot/orders/{NUM}/comments |
+| Ver comentarios | GET /bot/orders/{NUM}/comments |
 | Atualizar idioma | PATCH /bot/user/language |
 
 ⚠️ NAO EXISTEM: /bot/customers, /bot/devices, /bot/services, /bot/products, /bot/orders (sem /full /list /{NUM}), /bot/*/search, /bot/search (sem /unified)
@@ -113,6 +115,17 @@ Regras:
    - Nao existe → perguntar em qual OS ou criar nova
 3. "nova OS", "abrir outra", "criar OS" → SEMPRE criar nova
 4. Apos adicionar item → mostrar card atualizado (GET /details)
+
+---
+
+## COMENTARIOS / OBSERVACOES
+
+Quando o usuario pedir: anotar, observacao, nota, comentario, lembrete na OS → POST /bot/orders/{NUM}/comments
+- Body: `{"text":"conteudo"}` (isInternal:true por padrao = nota interna da equipe)
+- Para comentario visivel ao cliente: `{"text":"conteudo","isInternal":false}`
+- Listar: GET /bot/orders/{NUM}/comments
+
+Gatilhos: "anota na OS", "observacao", "nota", "adicionar comentario", "registrar que..."
 
 ---
 

--- a/backend/bot/workspace/skills/praticos/references/api-endpoints.md
+++ b/backend/bot/workspace/skills/praticos/references/api-endpoints.md
@@ -47,6 +47,13 @@ GET /bot/orders/{NUM}/photos - listar (retorna downloadUrl)
 GET /bot/orders/{NUM}/photos/{ID} - download binario
 DELETE /bot/orders/{NUM}/photos/{ID}
 
+## Comentarios
+POST /bot/orders/{NUM}/comments `{"text":"observacao aqui"}` (isInternal:true por padrao)
+Para comentario visivel ao cliente: `{"text":"mensagem","isInternal":false}`
+GET /bot/orders/{NUM}/comments - listar todos (internos + publicos)
+exec(command="curl -s -X POST -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" -H \"Content-Type: application/json\" -d '{\"text\":\"Peca encomendada, chega amanha\"}' \"$PRATICOS_API_URL/bot/orders/42/comments\"")
+exec(command="curl -s -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" \"$PRATICOS_API_URL/bot/orders/42/comments\"")
+
 ## Entidades CRUD
 Base: /bot/entities/{TIPO} (customers|devices|services|products)
 GET ?q=filtro&limit=20 | GET /{id} | POST | PATCH /{id} | DELETE /{id}

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -151,6 +151,7 @@ import botUnifiedSearchRoutes from './routes/bot/unified-search.routes';
 import botEntitiesRoutes from './routes/bot/entities.routes';
 import botFormsRoutes from './routes/bot/forms.routes';
 import botShareRoutes from './routes/bot/share.routes';
+import botCommentsRoutes from './routes/bot/comments.routes';
 import botRegistrationRoutes from './routes/bot/registration.routes';
 import botUserRoutes from './routes/bot/user.routes';
 
@@ -294,6 +295,7 @@ app.use('/bot/orders', botLimiter, botAuth, botOrdersManagementRoutes);
 app.use('/bot/orders', botLimiter, botAuth, botPhotosRoutes);
 app.use('/bot/orders', botLimiter, botAuth, botFormsRoutes);
 app.use('/bot/orders', botLimiter, botAuth, botShareRoutes);
+app.use('/bot/orders', botLimiter, botAuth, botCommentsRoutes);
 app.use('/bot/forms', botLimiter, botAuth, botFormsRoutes);
 app.use('/bot/summary', botLimiter, botAuth, summaryRoutes);
 app.use('/bot/analytics', botLimiter, botAuth, botAnalyticsRoutes);

--- a/firebase/functions/src/routes/bot/comments.routes.ts
+++ b/firebase/functions/src/routes/bot/comments.routes.ts
@@ -1,0 +1,170 @@
+/**
+ * Bot Comments Routes
+ * Endpoints for order comments/notes via Bot
+ */
+
+import { Router, Response } from 'express';
+import { AuthenticatedRequest } from '../../models/types';
+import { requireLinked } from '../../middleware/auth.middleware';
+import { getUserAggr } from '../../middleware/company.middleware';
+import * as orderService from '../../services/order.service';
+import * as commentService from '../../services/comment.service';
+import { timestampToDate } from '../../utils/date.utils';
+
+const router: Router = Router();
+
+/**
+ * POST /bot/orders/:number/comments
+ * Add a comment/note to an order
+ */
+router.post('/:number/comments', requireLinked, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const companyId = req.userContext?.companyId;
+
+    if (!companyId) {
+      res.status(401).json({
+        success: false,
+        error: { code: 'UNAUTHORIZED', message: 'Company context required' },
+      });
+      return;
+    }
+
+    const numberParam = Array.isArray(req.params.number) ? req.params.number[0] : req.params.number;
+    const orderNumber = parseInt(numberParam, 10);
+
+    if (isNaN(orderNumber)) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: 'Invalid order number' },
+      });
+      return;
+    }
+
+    const { text, isInternal = true } = req.body;
+
+    if (!text || typeof text !== 'string' || text.trim().length === 0) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: 'Comment text is required' },
+      });
+      return;
+    }
+
+    if (text.length > 2000) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: 'Comment text too long (max 2000 characters)' },
+      });
+      return;
+    }
+
+    // Get order by number
+    const order = await orderService.getOrderByNumber(companyId, orderNumber);
+    if (!order) {
+      res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: `Order #${orderNumber} not found` },
+      });
+      return;
+    }
+
+    const userAggr = getUserAggr(req);
+
+    const comment = await commentService.addComment(
+      companyId,
+      order.id,
+      text.trim(),
+      'internal',
+      {
+        name: userAggr.name,
+        userId: userAggr.id,
+      },
+      'bot',
+      isInternal
+    );
+
+    res.status(201).json({
+      success: true,
+      data: {
+        id: comment.id,
+        text: comment.text,
+        authorType: comment.authorType,
+        authorName: comment.author.name,
+        isInternal: comment.isInternal,
+        createdAt: timestampToDate(comment.createdAt)?.toISOString() || comment.createdAt,
+      },
+    });
+  } catch (error) {
+    console.error('Bot add comment error:', error);
+    res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: 'Failed to add comment' },
+    });
+  }
+});
+
+/**
+ * GET /bot/orders/:number/comments
+ * List comments for an order
+ */
+router.get('/:number/comments', requireLinked, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const companyId = req.userContext?.companyId;
+
+    if (!companyId) {
+      res.status(401).json({
+        success: false,
+        error: { code: 'UNAUTHORIZED', message: 'Company context required' },
+      });
+      return;
+    }
+
+    const numberParam = Array.isArray(req.params.number) ? req.params.number[0] : req.params.number;
+    const orderNumber = parseInt(numberParam, 10);
+
+    if (isNaN(orderNumber)) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: 'Invalid order number' },
+      });
+      return;
+    }
+
+    // Get order by number
+    const order = await orderService.getOrderByNumber(companyId, orderNumber);
+    if (!order) {
+      res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: `Order #${orderNumber} not found` },
+      });
+      return;
+    }
+
+    // Bot users are team members, include internal comments
+    const comments = await commentService.getComments(companyId, order.id, true);
+
+    res.json({
+      success: true,
+      data: {
+        comments: comments.map((c) => ({
+          id: c.id,
+          text: c.text,
+          authorType: c.authorType,
+          authorName: c.author.name,
+          isInternal: c.isInternal,
+          source: c.source,
+          createdAt: timestampToDate(c.createdAt)?.toISOString() || c.createdAt,
+        })),
+        count: comments.length,
+      },
+    });
+  } catch (error) {
+    console.error('Bot list comments error:', error);
+    res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: 'Failed to list comments' },
+    });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Add POST/GET `/bot/orders/:number/comments` endpoints for adding and listing order comments via bot
- Comments default to `isInternal: true` (team notes), with option to set `isInternal: false` for customer-visible messages
- Update bot skill docs (SKILL.md + api-endpoints.md) with new endpoints and usage instructions

Closes #173, closes #175

## Test plan
- [x] POST comment (internal) — 201, correct fields
- [x] POST comment (public, `isInternal: false`) — 201
- [x] GET comments — returns all with count
- [x] Validation: empty text → 400
- [x] Validation: non-existent order → 404
- [x] Author resolved correctly from linked user
- [ ] Verify comments appear in Flutter app with correct icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)