### PR TITLE
feat: add service location address to orders and customers

### DIFF
--- a/backend/bot/workspace/skills/praticos/references/os-card.md
+++ b/backend/bot/workspace/skills/praticos/references/os-card.md
@@ -18,6 +18,7 @@ Montar o texto a partir dos campos do `order`:
 📋 *O.S. #{number}* - {createdAt} - {STATUS}
 
 👤 *Cliente:* {customer.name}
+📍 *{ADDRESS_LABEL}:* {address}
 🔧 *{DEVICE_LABEL}:* {device.name} ({device.serial})
 
 🛠️ *Serviços:*
@@ -34,9 +35,9 @@ Montar o texto a partir dos campos do `order`:
 
 🔗 *Link:* {shareUrl}
 ```
-**Labels:** Traduzir no idioma do usuario. Referência pt-BR: Cliente, Serviços, Produtos, Total, Desconto, Pago, A receber, Previsão, Link. Ex en: Customer, Services, Products, Total, Discount, Paid, Balance, Due date, Link.
+**Labels:** Traduzir no idioma do usuario. Referência pt-BR: Cliente, Endereço, Serviços, Produtos, Total, Desconto, Pago, A receber, Previsão, Link. Ex en: Customer, Address, Services, Products, Total, Discount, Paid, Balance, Due date, Link.
 **Status:** Traduzir no idioma do usuario. Valores internos e referência pt-BR: quote=Orçamento | approved=Aprovado | progress=Em andamento | done=Concluído | canceled=Cancelado. Ex en: Quote | Approved | In progress | Completed | Canceled.
-**Omitir:** campos null, vazio ou com valor 0. Ex: paidAmount=0 → nao mostrar "Pago". discount=0 → nao mostrar "Desconto".
+**Omitir:** campos null, vazio ou com valor 0. Ex: paidAmount=0 → nao mostrar "Pago". discount=0 → nao mostrar "Desconto". address=null → nao mostrar "Endereço".
 **Moeda/Valores:** Usar `formatContext` retornado pelo endpoint `/bot/orders/{NUM}/details`. O `currency` define o simbolo (BRL=R$, EUR=€, USD=$) e o `locale` define o formato numerico: pt-BR → R$ 1.234,56 | en-US → $1,234.56 | fr-FR → 1 234,56 €. A API retorna valores raw (numeros).
 **remaining** = total - discount - paidAmount.
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1237,6 +1237,9 @@
       }
     }
   },
+  "serviceLocation": "Service Location",
+  "openInMaps": "Open in Maps",
+  "addressPlaceholder": "Street, number, neighborhood, city",
   "sendWhatsApp": "Send WhatsApp",
   "inviteWhatsAppBotMessage": "Hello! You have been added to the {company} team on PraticOS. Send a \"hi\" to the bot to get started: https://wa.me/5548988794742",
   "@inviteWhatsAppBotMessage": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1237,6 +1237,9 @@
       }
     }
   },
+  "serviceLocation": "Ubicación del Servicio",
+  "openInMaps": "Abrir en Mapa",
+  "addressPlaceholder": "Calle, número, barrio, ciudad",
   "sendWhatsApp": "Enviar WhatsApp",
   "inviteWhatsAppBotMessage": "¡Hola! Has sido agregado al equipo de {company} en PraticOS. Envía un \"hola\" al bot para comenzar: https://wa.me/5548988794742",
   "@inviteWhatsAppBotMessage": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5584,6 +5584,24 @@ abstract class AppLocalizations {
   /// **'{name} receberá o convite automaticamente ao entrar em contato com o bot PraticOS no WhatsApp.'**
   String inviteWhatsAppSuccessMessage(String name);
 
+  /// No description provided for @serviceLocation.
+  ///
+  /// In pt, this message translates to:
+  /// **'Local do Atendimento'**
+  String get serviceLocation;
+
+  /// No description provided for @openInMaps.
+  ///
+  /// In pt, this message translates to:
+  /// **'Abrir no Mapa'**
+  String get openInMaps;
+
+  /// No description provided for @addressPlaceholder.
+  ///
+  /// In pt, this message translates to:
+  /// **'Rua, número, bairro, cidade'**
+  String get addressPlaceholder;
+
   /// No description provided for @sendWhatsApp.
   ///
   /// In pt, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2931,6 +2931,15 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get serviceLocation => 'Service Location';
+
+  @override
+  String get openInMaps => 'Open in Maps';
+
+  @override
+  String get addressPlaceholder => 'Street, number, neighborhood, city';
+
+  @override
   String get sendWhatsApp => 'Send WhatsApp';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2947,6 +2947,15 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get serviceLocation => 'Ubicación del Servicio';
+
+  @override
+  String get openInMaps => 'Abrir en Mapa';
+
+  @override
+  String get addressPlaceholder => 'Calle, número, barrio, ciudad';
+
+  @override
   String get sendWhatsApp => 'Enviar WhatsApp';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2942,6 +2942,15 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get serviceLocation => 'Local do Atendimento';
+
+  @override
+  String get openInMaps => 'Abrir no Mapa';
+
+  @override
+  String get addressPlaceholder => 'Rua, número, bairro, cidade';
+
+  @override
   String get sendWhatsApp => 'Enviar WhatsApp';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1282,6 +1282,9 @@
       }
     }
   },
+  "serviceLocation": "Local do Atendimento",
+  "openInMaps": "Abrir no Mapa",
+  "addressPlaceholder": "Rua, número, bairro, cidade",
   "sendWhatsApp": "Enviar WhatsApp",
   "inviteWhatsAppBotMessage": "Olá! Você foi adicionado à equipe da {company} no PraticOS. Mande um \"oi\" para o bot para começar: https://wa.me/5548988794742",
   "@inviteWhatsAppBotMessage": {

--- a/lib/mobx/order_store.dart
+++ b/lib/mobx/order_store.dart
@@ -46,6 +46,15 @@ abstract class _OrderStore with Store {
   String? scheduledDate;
 
   @observable
+  String? address;
+
+  @observable
+  double? latitude;
+
+  @observable
+  double? longitude;
+
+  @observable
   String? status;
 
   @observable
@@ -260,6 +269,9 @@ abstract class _OrderStore with Store {
       order!.createdBy = Global.userAggr;
       order!.status = 'quote';
       status = order!.status;
+      address = null;
+      latitude = null;
+      longitude = null;
       order!.payment = 'unpaid';
       payment = order!.payment;
       updatePayment();
@@ -315,6 +327,9 @@ abstract class _OrderStore with Store {
         ? FormatService().formatDateTime(order.scheduledDate!)
         : null;
     status = order.status;
+    address = order.address;
+    latitude = order.latitude;
+    longitude = order.longitude;
     updateTotal();
     updatePayment();
   }
@@ -328,6 +343,12 @@ abstract class _OrderStore with Store {
 
     order!.customer = c.toAggr();
     customer = order!.customer;
+
+    // Auto-fill address from customer if OS has no address yet
+    if ((address == null || address!.isEmpty) && c.address != null && c.address!.isNotEmpty) {
+      setAddress(c.address, lat: c.latitude, lng: c.longitude);
+    }
+
     createItem();
   }
 
@@ -351,6 +372,17 @@ abstract class _OrderStore with Store {
     scheduledDate = FormatService().formatDateTime(date);
     createItem();
     _scheduleReminder(reminderStore);
+  }
+
+  @action
+  void setAddress(String? text, {double? lat, double? lng}) {
+    order!.address = text;
+    order!.latitude = lat;
+    order!.longitude = lng;
+    address = text;
+    latitude = lat;
+    longitude = lng;
+    createItem();
   }
 
   @action

--- a/lib/mobx/order_store.g.dart
+++ b/lib/mobx/order_store.g.dart
@@ -189,6 +189,60 @@ mixin _$OrderStore on _OrderStore, Store {
     });
   }
 
+  late final _$addressAtom = Atom(
+    name: '_OrderStore.address',
+    context: context,
+  );
+
+  @override
+  String? get address {
+    _$addressAtom.reportRead();
+    return super.address;
+  }
+
+  @override
+  set address(String? value) {
+    _$addressAtom.reportWrite(value, super.address, () {
+      super.address = value;
+    });
+  }
+
+  late final _$latitudeAtom = Atom(
+    name: '_OrderStore.latitude',
+    context: context,
+  );
+
+  @override
+  double? get latitude {
+    _$latitudeAtom.reportRead();
+    return super.latitude;
+  }
+
+  @override
+  set latitude(double? value) {
+    _$latitudeAtom.reportWrite(value, super.latitude, () {
+      super.latitude = value;
+    });
+  }
+
+  late final _$longitudeAtom = Atom(
+    name: '_OrderStore.longitude',
+    context: context,
+  );
+
+  @override
+  double? get longitude {
+    _$longitudeAtom.reportRead();
+    return super.longitude;
+  }
+
+  @override
+  set longitude(double? value) {
+    _$longitudeAtom.reportWrite(value, super.longitude, () {
+      super.longitude = value;
+    });
+  }
+
   late final _$statusAtom = Atom(name: '_OrderStore.status', context: context);
 
   @override
@@ -974,6 +1028,18 @@ mixin _$OrderStore on _OrderStore, Store {
   }
 
   @override
+  void setAddress(String? text, {double? lat, double? lng}) {
+    final _$actionInfo = _$_OrderStoreActionController.startAction(
+      name: '_OrderStore.setAddress',
+    );
+    try {
+      return super.setAddress(text, lat: lat, lng: lng);
+    } finally {
+      _$_OrderStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
   dynamic clearScheduledDate() {
     final _$actionInfo = _$_OrderStoreActionController.startAction(
       name: '_OrderStore.clearScheduledDate',
@@ -1257,6 +1323,9 @@ orderStream: ${orderStream},
 formsStream: ${formsStream},
 dueDate: ${dueDate},
 scheduledDate: ${scheduledDate},
+address: ${address},
+latitude: ${latitude},
+longitude: ${longitude},
 status: ${status},
 createdAt: ${createdAt},
 total: ${total},

--- a/lib/models/customer.dart
+++ b/lib/models/customer.dart
@@ -11,6 +11,8 @@ class Customer extends BaseAuditCompany {
   String? phone;
   String? email;
   String? address;
+  double? latitude;
+  double? longitude;
   List<String>? keywords;
 
   Customer();

--- a/lib/models/customer.g.dart
+++ b/lib/models/customer.g.dart
@@ -27,6 +27,8 @@ Customer _$CustomerFromJson(Map<String, dynamic> json) => Customer()
   ..phone = json['phone'] as String?
   ..email = json['email'] as String?
   ..address = json['address'] as String?
+  ..latitude = (json['latitude'] as num?)?.toDouble()
+  ..longitude = (json['longitude'] as num?)?.toDouble()
   ..keywords = (json['keywords'] as List<dynamic>?)
       ?.map((e) => e as String)
       .toList();
@@ -42,6 +44,8 @@ Map<String, dynamic> _$CustomerToJson(Customer instance) => <String, dynamic>{
   'phone': instance.phone,
   'email': instance.email,
   'address': instance.address,
+  'latitude': instance.latitude,
+  'longitude': instance.longitude,
   'keywords': instance.keywords,
 };
 

--- a/lib/models/order.dart
+++ b/lib/models/order.dart
@@ -43,6 +43,11 @@ class Order extends BaseAuditCompany {
   /// Avaliação do cliente
   OrderRating? rating;
 
+  /// Service location address
+  String? address;
+  double? latitude;
+  double? longitude;
+
   /// Retorna a URL da primeira foto (capa da OS)
   String? get coverPhotoUrl => photos?.isNotEmpty == true ? photos!.first.url : null;
 

--- a/lib/models/order.g.dart
+++ b/lib/models/order.g.dart
@@ -63,7 +63,10 @@ Order _$OrderFromJson(Map<String, dynamic> json) => Order()
       : OrderShareLink.fromJson(json['shareLink'] as Map<String, dynamic>)
   ..rating = json['rating'] == null
       ? null
-      : OrderRating.fromJson(json['rating'] as Map<String, dynamic>);
+      : OrderRating.fromJson(json['rating'] as Map<String, dynamic>)
+  ..address = json['address'] as String?
+  ..latitude = (json['latitude'] as num?)?.toDouble()
+  ..longitude = (json['longitude'] as num?)?.toDouble();
 
 Map<String, dynamic> _$OrderToJson(Order instance) => <String, dynamic>{
   'id': instance.id,
@@ -91,6 +94,9 @@ Map<String, dynamic> _$OrderToJson(Order instance) => <String, dynamic>{
   'assignedTo': instance.assignedTo?.toJson(),
   'shareLink': instance.shareLink?.toJson(),
   'rating': instance.rating?.toJson(),
+  'address': instance.address,
+  'latitude': instance.latitude,
+  'longitude': instance.longitude,
 };
 
 OrderAggr _$OrderAggrFromJson(Map<String, dynamic> json) => OrderAggr()

--- a/lib/screens/customers/customer_form_screen.dart
+++ b/lib/screens/customers/customer_form_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:praticos/mobx/customer_store.dart';
 import 'package:praticos/models/customer.dart';
+import 'package:praticos/services/location_service.dart';
 import 'package:praticos/widgets/dynamic_text_field.dart';
 import 'package:praticos/extensions/context_extensions.dart';
 
@@ -70,7 +71,7 @@ class _CustomerFormScreenState extends State<CustomerFormScreen> {
           child: ListView(
             children: [
               const SizedBox(height: 20),
-              
+
               // Header Icon (Placeholder since no photo)
               Center(
                 child: Container(
@@ -119,12 +120,37 @@ class _CustomerFormScreenState extends State<CustomerFormScreen> {
                     onSaved: (val) => _customer?.email = val,
                   ),
                   CupertinoTextFormFieldRow(
-                    prefix: Text(context.l10n.address,
-                        style: const TextStyle(fontSize: 16)),
+                    prefix: GestureDetector(
+                      onTap: (_customer?.address != null && _customer!.address!.isNotEmpty) ||
+                              (_customer?.latitude != null && _customer?.longitude != null)
+                          ? () => LocationService().openInMaps(
+                                lat: _customer?.latitude,
+                                lng: _customer?.longitude,
+                                address: _customer?.address,
+                              )
+                          : null,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            CupertinoIcons.location_solid,
+                            size: 16,
+                            color: (_customer?.address != null && _customer!.address!.isNotEmpty) ||
+                                    (_customer?.latitude != null && _customer?.longitude != null)
+                                ? CupertinoTheme.of(context).primaryColor
+                                : CupertinoColors.systemGrey.resolveFrom(context),
+                          ),
+                          const SizedBox(width: 4),
+                          Text(context.l10n.address,
+                              style: const TextStyle(fontSize: 16)),
+                        ],
+                      ),
+                    ),
                     initialValue: _customer?.address,
-                    placeholder: context.l10n.address,
+                    placeholder: context.l10n.addressPlaceholder,
                     textCapitalization: TextCapitalization.sentences,
                     textAlign: TextAlign.right,
+                    onChanged: (val) => _customer?.address = val,
                     onSaved: (val) => _customer?.address = val,
                   ),
                 ],

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:url_launcher/url_launcher.dart';
+
+/// Service for map integration
+class LocationService {
+  /// Open location in external maps app
+  Future<void> openInMaps({double? lat, double? lng, String? address}) async {
+    Uri uri;
+
+    if (lat != null && lng != null) {
+      if (Platform.isIOS) {
+        uri = Uri.parse('https://maps.apple.com/?q=$lat,$lng');
+      } else {
+        uri = Uri.parse('geo:$lat,$lng?q=$lat,$lng');
+      }
+    } else if (address != null && address.isNotEmpty) {
+      final encoded = Uri.encodeComponent(address);
+      if (Platform.isIOS) {
+        uri = Uri.parse('https://maps.apple.com/?q=$encoded');
+      } else {
+        uri = Uri.parse('geo:0,0?q=$encoded');
+      }
+    } else {
+      return;
+    }
+
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+}

--- a/lib/services/pdf/pdf_localizations.dart
+++ b/lib/services/pdf/pdf_localizations.dart
@@ -55,6 +55,7 @@ class PdfLocalizations {
   final String photosAvailableDigitally;
   final String photoRecord;
   final String partsAndProducts;
+  final String serviceLocation;
 
   // Form-related strings
   final String statusCompleted;
@@ -92,6 +93,7 @@ class PdfLocalizations {
     required this.photosAvailableDigitally,
     required this.photoRecord,
     required this.partsAndProducts,
+    required this.serviceLocation,
     required this.statusCompleted,
     required this.statusInProgress,
     required this.statusPending,
@@ -130,6 +132,7 @@ class PdfLocalizations {
       photosAvailableDigitally: _latinCharactersOnly(l10n.photosAvailableDigitally),
       photoRecord: _latinCharactersOnly(l10n.photoRecord),
       partsAndProducts: _latinCharactersOnly(l10n.partsAndProducts),
+      serviceLocation: _latinCharactersOnly(l10n.serviceLocation),
       statusCompleted: _latinCharactersOnly(l10n.statusCompleted),
       statusInProgress: _latinCharactersOnly(l10n.statusInProgress),
       statusPending: _latinCharactersOnly(l10n.statusPending),

--- a/lib/services/pdf/pdf_main_os_builder.dart
+++ b/lib/services/pdf/pdf_main_os_builder.dart
@@ -854,6 +854,37 @@ class PdfMainOsBuilder {
         ],
       ),
 
+      // Service Location
+      if (order.address != null && order.address!.isNotEmpty)
+        pw.Container(
+          width: double.infinity,
+          margin: const pw.EdgeInsets.only(top: 8),
+          padding: const pw.EdgeInsets.all(10),
+          decoration: PdfStyles.cardDecoration(),
+          child: pw.Row(
+            children: [
+              pw.Text(
+                '${localizations.serviceLocation}: ',
+                style: pw.TextStyle(
+                  font: boldFont,
+                  fontSize: 9,
+                  color: PdfStyles.primaryDark,
+                ),
+              ),
+              pw.Expanded(
+                child: pw.Text(
+                  order.address!,
+                  style: pw.TextStyle(
+                    font: baseFont,
+                    fontSize: 9,
+                    color: PdfColors.grey800,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+
       pw.SizedBox(height: 20),
 
       // Services Section


### PR DESCRIPTION
## Summary
- Add `address`, `latitude`, `longitude` fields to Order and Customer models
- Inline address text field in order form with auto-fill from selected customer
- Clickable location icon opens maps app (Apple Maps on iOS, Google Maps on Android)
- Coordinates from API/auto-fill are preserved when editing address text
- Address displayed in PDF output and bot OS card

## Test plan
- [ ] Create new OS, select customer with address → address auto-fills
- [ ] Edit address text → coordinates preserved, icon stays clickable
- [ ] Clear address → coordinates cleared, icon turns grey
- [ ] Tap location icon with address → opens maps app
- [ ] Edit customer → address field with clickable icon works
- [ ] Generate PDF with address → address shown in output
- [ ] Bot OS card shows address when present, omits when null
- [ ] Dark mode: all colors adapt correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)