### PR TITLE
fix(devices): preserve category/manufacturer when editing from order

### DIFF
--- a/firebase/scripts/seed_segments.js
+++ b/firebase/scripts/seed_segments.js
@@ -398,7 +398,6 @@ const SEGMENTS = [
         key: 'device.year',
         type: 'number',
         labels: { 'pt-BR': 'Ano', 'en-US': 'Year', 'es-ES': 'Año' },
-        required: true,
         min: 1900,
         max: 2030,
         section: 'Identificação',
@@ -512,7 +511,6 @@ const SEGMENTS = [
         key: 'device.btus',
         type: 'select',
         labels: { 'pt-BR': 'BTUs', 'en-US': 'BTUs', 'es-ES': 'BTUs' },
-        required: true,
         options: ['7000', '9000', '12000', '18000', '22000', '24000', '30000'],
         optionsI18n: [
           { value: '7000', labels: { 'pt-BR': '7000', 'en-US': '7000', 'es-ES': '7000' } },
@@ -531,7 +529,6 @@ const SEGMENTS = [
         key: 'device.voltage',
         type: 'select',
         labels: { 'pt-BR': 'Voltagem', 'en-US': 'Voltage', 'es-ES': 'Voltaje' },
-        required: true,
         options: ['110V', '220V', 'two_phase'],
         optionsI18n: [
           { value: '110V', labels: { 'pt-BR': '110V', 'en-US': '110V', 'es-ES': '110V' } },
@@ -775,7 +772,6 @@ const SEGMENTS = [
         key: 'device.voltage',
         type: 'select',
         labels: { 'pt-BR': 'Voltagem', 'en-US': 'Voltage', 'es-ES': 'Voltaje' },
-        required: true,
         options: ['110V', '220V', 'dual_voltage'],
         optionsI18n: [
           { value: '110V', labels: { 'pt-BR': '110V', 'en-US': '110V', 'es-ES': '110V' } },

--- a/lib/mobx/device_store.dart
+++ b/lib/mobx/device_store.dart
@@ -37,13 +37,24 @@ abstract class _DeviceStore with Store {
   saveDevice(Device device) async {
     if (companyId == null) return;
     User? user = await (userStore.getSingleUserById());
-    device.createdAt = DateTime.now();
-    device.createdBy = user?.toAggr();
+
+    final isEditing = device.id != null;
+
+    if (!isEditing) {
+      device.createdAt = DateTime.now();
+      device.createdBy = user?.toAggr();
+    }
+
     device.company = Global.companyAggr;
     device.updatedAt = DateTime.now();
     device.updatedBy = user?.toAggr();
     device.keywords = generateKeywords(device.name);
-    await repository.createItem(companyId!, device);
+
+    if (isEditing) {
+      await repository.updateItem(companyId!, device);
+    } else {
+      await repository.createItem(companyId!, device);
+    }
   }
 
   @action

--- a/lib/models/device.dart
+++ b/lib/models/device.dart
@@ -28,6 +28,8 @@ class DeviceAggr extends BaseAuditCompanyAggr {
   String? serial;
   String? name;
   String? photo;
+  String? category;
+  String? manufacturer;
 
   DeviceAggr();
   factory DeviceAggr.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/device.g.dart
+++ b/lib/models/device.g.dart
@@ -55,7 +55,9 @@ DeviceAggr _$DeviceAggrFromJson(Map<String, dynamic> json) => DeviceAggr()
   ..id = json['id'] as String?
   ..serial = json['serial'] as String?
   ..name = json['name'] as String?
-  ..photo = json['photo'] as String?;
+  ..photo = json['photo'] as String?
+  ..category = json['category'] as String?
+  ..manufacturer = json['manufacturer'] as String?;
 
 Map<String, dynamic> _$DeviceAggrToJson(DeviceAggr instance) =>
     <String, dynamic>{
@@ -63,4 +65,6 @@ Map<String, dynamic> _$DeviceAggrToJson(DeviceAggr instance) =>
       'serial': instance.serial,
       'name': instance.name,
       'photo': instance.photo,
+      'category': instance.category,
+      'manufacturer': instance.manufacturer,
     };

--- a/lib/screens/order_form.dart
+++ b/lib/screens/order_form.dart
@@ -14,6 +14,7 @@ import 'package:praticos/mobx/order_store.dart';
 import 'package:praticos/models/company.dart';
 import 'package:praticos/models/customer.dart';
 import 'package:praticos/models/device.dart';
+import 'package:praticos/repositories/v2/device_repository_v2.dart';
 import 'package:praticos/models/order.dart';
 import 'package:praticos/models/permission.dart';
 import 'package:praticos/screens/widgets/order_photos_widget.dart';
@@ -1659,9 +1660,13 @@ class _OrderFormState extends State<OrderForm> {
     });
   }
 
-  void _editDevice(DeviceAggr deviceAggr) {
-    // Convert DeviceAggr to Device for the form screen
-    final device = Device.fromJson(deviceAggr.toJson());
+  void _editDevice(DeviceAggr deviceAggr) async {
+    // Fetch full Device from Firestore to preserve all fields (category, manufacturer, etc.)
+    final fullDevice = _store.companyId != null
+        ? await DeviceRepositoryV2().getSingle(_store.companyId!, deviceAggr.id)
+        : null;
+    final device = fullDevice ?? Device.fromJson(deviceAggr.toJson());
+    if (!mounted) return;
     Navigator.pushNamed(
       context,
       '/device_form',


### PR DESCRIPTION
## Summary

Closes #195

- **DeviceAggr** now includes `category` and `manufacturer` fields so they persist in the aggregate form embedded in orders
- **`_editDevice()`** in `order_form.dart` fetches the full Device document from Firestore instead of converting from DeviceAggr (which lost fields like `description`, `customData`, `category`, `manufacturer`)
- **`DeviceStore.saveDevice()`** distinguishes create vs update: preserves `createdAt`/`createdBy` on edits and uses `updateItem` for existing devices
- Removed `required` constraint from segment custom fields (`device.year`, `device.btus`, `device.voltage`) since they are optional specification fields

## Test plan

- [ ] Create a new device with category and manufacturer — verify it saves correctly
- [ ] Edit an existing device from the device list — category/manufacturer should appear and save
- [ ] Edit a device from within an order (OS) — category/manufacturer should load from Firestore and save
- [ ] Verify in Firestore that `description`, `customData` and other existing fields are not overwritten with null
- [ ] Verify that `createdAt`/`createdBy` are preserved on edits
- [ ] Verify custom fields (year, btus, voltage) are no longer required in the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)