### PR TITLE
ci: add Cloud Run auto-deploy for Nuxt SSR

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy Nuxt SSR to Cloud Run
+
+on:
+  push:
+    branches: [master]
+    paths: ['firebase/web/**']
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: praticos
+  SERVICE_NAME: praticos-web
+  REGION: southamerica-east1
+  IMAGE: gcr.io/praticos/praticos-web
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_PRATICOS }}'
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: praticos
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker --quiet
+
+      - name: Build Docker image
+        working-directory: firebase/web
+        run: docker build -t ${{ env.IMAGE }}:${{ github.sha }} -t ${{ env.IMAGE }}:latest .
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:latest
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy ${{ env.SERVICE_NAME }} \
+            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --region ${{ env.REGION }} \
+            --platform managed \
+            --allow-unauthenticated \
+            --port 3000 \
+            --memory 512Mi \
+            --min-instances 0 \
+            --max-instances 3 \
+            --quiet

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -39,7 +39,10 @@
     "rewrites": [
       {
         "source": "/q/**",
-        "destination": "/order/index.html"
+        "run": {
+          "serviceId": "praticos-web",
+          "region": "southamerica-east1"
+        }
       },
       {
         "source": "/pro/**",


### PR DESCRIPTION
## Summary
- Cria workflow GitHub Actions para build e deploy automático do Nuxt SSR (`firebase/web/`) no Cloud Run
- Trigger: push na master com mudanças em `firebase/web/**` + dispatch manual
- Redireciona `/q/**` do SPA estático para Cloud Run (SSR completo com SEO e meta tags)

## Detalhes
- Imagem Docker tagueada com SHA do commit + `latest` no `gcr.io/praticos/praticos-web`
- Usa `google-github-actions/auth@v2` com `FIREBASE_SERVICE_ACCOUNT_PRATICOS` (mesmo padrão do bot)
- Cloud Run: 512Mi RAM, 0-3 instâncias, porta 3000

## Pré-requisitos (manual)
A service account precisa ter no GCP IAM:
- **Cloud Run Admin** (`roles/run.admin`)
- **Storage Admin** (`roles/storage.admin`)
- **Service Account User** (`roles/iam.serviceAccountUser`)

## Test plan
- [ ] Verificar que a service account tem as permissões necessárias
- [ ] Merge e confirmar que workflow é triggerado pelo path `firebase/web/**`
- [ ] Confirmar build Docker + push ao GCR com sucesso
- [ ] Acessar `https://praticos.web.app/q/{token}` e verificar SSR (view-source com meta tags)
- [ ] Testar `workflow_dispatch` manual
- [ ] Confirmar que mudanças fora de `firebase/web/` não triggam o workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)