### PR TITLE
ci: simplify Cloud Run deploy with source build

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -7,10 +7,8 @@ on:
   workflow_dispatch:
 
 env:
-  PROJECT_ID: praticos
   SERVICE_NAME: praticos-web
   REGION: southamerica-east1
-  IMAGE: gcr.io/praticos/praticos-web
 
 jobs:
   deploy:
@@ -28,24 +26,12 @@ jobs:
         with:
           project_id: praticos
 
-      - name: Configure Docker for GCR
-        run: gcloud auth configure-docker --quiet
-
-      - name: Build Docker image
+      - name: Deploy to Cloud Run (source build)
         working-directory: firebase/web
-        run: docker build -t ${{ env.IMAGE }}:${{ github.sha }} -t ${{ env.IMAGE }}:latest .
-
-      - name: Push Docker image
-        run: |
-          docker push ${{ env.IMAGE }}:${{ github.sha }}
-          docker push ${{ env.IMAGE }}:latest
-
-      - name: Deploy to Cloud Run
         run: |
           gcloud run deploy ${{ env.SERVICE_NAME }} \
-            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --source . \
             --region ${{ env.REGION }} \
-            --platform managed \
             --allow-unauthenticated \
             --port 3000 \
             --memory 512Mi \


### PR DESCRIPTION
## Summary
- Simplifica o workflow de deploy do Cloud Run usando `--source .` em vez de build/push manual da imagem Docker
- Cloud Build cuida do build do Dockerfile automaticamente
- Remove 3 steps do workflow (Docker auth, build, push)

## Mudanças
- Remove envs `PROJECT_ID` e `IMAGE` (não mais necessárias)
- Remove steps: Configure Docker, Build image, Push image
- Substitui `--image` por `--source .` no deploy
- Remove `--platform managed` (já é o padrão)

## Pré-requisitos
A service account precisa de **Cloud Build Editor** (`roles/cloudbuild.builds.editor`) além de Cloud Run Admin.

## Test plan
- [ ] Verificar que workflow é triggerado por mudanças em `firebase/web/**`
- [ ] Confirmar que Cloud Build builda o Dockerfile com sucesso
- [ ] Acessar `https://praticos.web.app/pro/{slug}` e verificar SSR

🤖 Generated with [Claude Code](https://claude.com/claude-code)