### PR TITLE
fix(bot): foto upload resiliente a context pruning

### DIFF
--- a/backend/bot/workspace/skills/praticos/SKILL.md
+++ b/backend/bot/workspace/skills/praticos/SKILL.md
@@ -60,7 +60,11 @@ Boas-vindas: UMA frase curta com [userName]. Se houver OS pendentes (GET /bot/su
 1. **IDs OBRIGATORIOS** — API NAO aceita nomes. Usar POST /bot/search/unified.
 2. **Criar OS:** busca → IDs → criar. Apos criar → OS ativa. Adicionar item: se ha OS ativa, usar /services ou /products. So criar nova se pedido explicitamente.
 3. **CRUD:** buscar primeiro, confirmar editar/excluir. Criar CLIENTE: pedir contato WhatsApp (vCard). ⚠️ Telefone do vCard = dado do CLIENTE (campo `phone`). NUNCA usar como {NUMERO}.
-4. **Fotos:** multipart `-F "file=@/path"` (NAO base64)
+4. **Fotos:** upload via /photos/upload (multipart).
+   exec(command="curl -s -X POST -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" -F \"file=@/path/to/photo.jpg\" \"$PRATICOS_API_URL/bot/orders/{NUM}/photos/upload\"")
+   - Multiplas fotos: uma chamada por foto
+   - Listar: GET /bot/orders/{NUM}/photos
+   - Deletar: DELETE /bot/orders/{NUM}/photos/{ID}
 5. **Valores:** busca retorna `value`. Omitir = catalogo. Brinde = `"value":0`
    - 🔴 Valor na OS = serviço ou produto. Se usuario pedir para "colocar/registrar/atualizar valor" na OS → buscar servico no catalogo (POST /bot/search/unified) e adicionar via /services. Se nao encontrar → criar novo servico (POST /bot/entities/services) e depois adicionar via /services. NUNCA usar /comments para definir valor da OS.
    - Comentario com valor so se usuario pedir EXPLICITAMENTE para anotar/observar (ex: "anota que o valor combinado foi 700").

--- a/backend/bot/workspace/skills/praticos/references/api-endpoints.md
+++ b/backend/bot/workspace/skills/praticos/references/api-endpoints.md
@@ -48,6 +48,7 @@ GET /bot/orders/{NUM}/details retorna `devices[]` (lista completa) e `deviceCoun
 
 ## OS - Fotos
 POST /bot/orders/{NUM}/photos/upload - multipart com -F "file=@/path"
+exec(command="curl -s -X POST -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" -F \"file=@/path/to/photo.jpg\" \"$PRATICOS_API_URL/bot/orders/{NUM}/photos/upload\"")
 GET /bot/orders/{NUM}/photos - listar (retorna downloadUrl)
 GET /bot/orders/{NUM}/photos/{ID} - download binario
 DELETE /bot/orders/{NUM}/photos/{ID}


### PR DESCRIPTION
## Resumo

- Adiciona exemplo `exec` completo do endpoint `/photos/upload` (multipart) diretamente no SKILL.md, dentro do bootstrap de 8000 chars que sobrevive ao context pruning
- Adiciona exemplo `exec` correspondente no `api-endpoints.md`
- Remove todas as referências ao endpoint legacy `/photos` (base64) para que o modelo nem saiba que existe

## Contexto

O bot perdia a referência do endpoint correto após context pruning do Gemini, e acabava usando `/photos` (base64) ou formato incorreto, resultando em 400 de validação.

## Test plan

- [ ] `make dev` no `backend/bot/`
- [ ] Enviar foto via WhatsApp ao bot local e verificar que usa `/photos/upload`
- [ ] Após validar, `make sync` para aplicar em produção sem rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)