### PR TITLE
fix(bot): prevent OS duplication and unnecessary service creation

### DIFF
--- a/backend/bot/workspace/skills/praticos/SKILL.md
+++ b/backend/bot/workspace/skills/praticos/SKILL.md
@@ -57,6 +57,12 @@ Boas-vindas: UMA frase curta com [userName]. Se houver OS pendentes (GET /bot/su
 /bot/link/context retorna `segment.labels`. SEMPRE usar: device._entity, device.serial, device.brand, customer._entity, service_order._entity, status.in_progress. Se label nao existir, usar generico.
 
 ### REGRAS
+🔴 **ANTI-DUPLICACAO:** NUNCA criar POST /bot/orders/full sem TODOS os dados resolvidos (customer correto, device, servicos).
+   - Primeiro: resolver TODOS os IDs (search/unified) e confirmar com usuario se ambiguo
+   - Depois: UMA UNICA chamada POST /bot/orders/full com tudo preenchido
+   - Se errou cliente/device numa OS ja criada → usar PATCH /:number/customer ou PATCH /:number/device. NAO criar nova OS.
+   - Se faltou servico → usar POST /:number/services na OS existente. NAO criar nova OS.
+
 1. **IDs OBRIGATORIOS** — API NAO aceita nomes. Usar POST /bot/search/unified.
 2. **Criar OS:** busca → IDs → criar. Apos criar → OS ativa. Adicionar item: se ha OS ativa, usar /services ou /products. So criar nova se pedido explicitamente.
 3. **CRUD:** buscar primeiro, confirmar editar/excluir. Criar CLIENTE: pedir contato WhatsApp (vCard). ⚠️ Telefone do vCard = dado do CLIENTE (campo `phone`). NUNCA usar como {NUMERO}.
@@ -69,11 +75,17 @@ Boas-vindas: UMA frase curta com [userName]. Se houver OS pendentes (GET /bot/su
    - 🔴 Valor na OS = serviço ou produto. Se usuario pedir para "colocar/registrar/atualizar valor" na OS → buscar servico no catalogo (POST /bot/search/unified) e adicionar via /services. Se nao encontrar → criar novo servico (POST /bot/entities/services) e depois adicionar via /services. NUNCA usar /comments para definir valor da OS.
    - Comentario com valor so se usuario pedir EXPLICITAMENTE para anotar/observar (ex: "anota que o valor combinado foi 700").
    - 🔴 **SERVICOS VIA AUDIO/TEXTO/FOTO — CADA UM DEVE SER ITEM NA OS:**
-     a) Buscar no catalogo (POST /bot/search/unified)
-     b) Se encontrou → adicionar via POST /orders/{NUM}/services
-     c) Se NAO encontrou → criar servico (POST /bot/entities/services) → adicionar via /services
-     d) NUNCA usar /comments como fallback para listar servicos ou valores
-     e) NUNCA duplicar info de servicos ja adicionados como comentario "resumo"
+     a) Buscar no catalogo (POST /bot/search/unified) com arrays para todos os termos de uma vez
+     b) Se encontrou match exato em `results` → usar diretamente via POST /orders/{NUM}/services
+     c) Se NAO encontrou exato mas `available` tem servico SIMILAR (ex: "Pintura de Para-lama" quando usuario pediu "Pintura de Para-lama Esquerdo") → usar o servico do `available` e passar `description` com o detalhe especifico. Ex: serviceId do "Pintura de Para-lama", description: "Pintura de Para-lama Esquerdo"
+     d) Se NAO encontrou nada similar em `results` NEM `available` → criar servico (POST /bot/entities/services) → adicionar via /services
+     e) NUNCA usar /comments como fallback para listar servicos ou valores
+     f) NUNCA duplicar info de servicos ja adicionados como comentario "resumo"
+   - 🔴 NUNCA criar servico novo no catalogo se existe um similar. Usar `description` para especificar.
+     Exemplos de match por similaridade:
+     - "Pintura de Para-lama Esquerdo" → usar "Pintura de Para-lama" + description "Para-lama Esquerdo"
+     - "Troca de oleo 5W30" → usar "Troca de oleo" + description "Oleo 5W30"
+     - "Instalacao split 12k sala" → usar "Instalacao de ar condicionado" + description "Split 12k - Sala"
 6. **Exibir OS:** ver CARD DE OS abaixo
 7. 🔴 **Apos criar OS:** SEMPRE exibir card (GET /details → formato CARD DE OS abaixo) + oferecer compartilhar → POST /bot/orders/{NUM}/share
 
@@ -112,6 +124,7 @@ Regras:
    - Nao existe → perguntar em qual OS ou criar nova
 3. "nova OS", "abrir outra", "criar OS" → SEMPRE criar nova
 4. Apos adicionar item → mostrar card atualizado (GET /details)
+5. 🔴 Se a OS ativa tem dados errados (cliente, device) → corrigir via PATCH. NUNCA criar nova OS para corrigir erro.
 
 ---
 

--- a/backend/bot/workspace/skills/praticos/references/api-endpoints.md
+++ b/backend/bot/workspace/skills/praticos/references/api-endpoints.md
@@ -7,6 +7,9 @@ POST /bot/search/unified
 Parametros JSON (string OU array de strings): customer, customerPhone, device, deviceSerial, service, product
 Exemplo com arrays: {"service":["tela","bateria"],"product":["película"]}
 Resposta: {exact, suggestions, available}
+- `results` = matches exatos/fortes. Usar diretamente.
+- `available` = matches parciais/fuzzy. Usar com `description` customizada quando similar ao pedido do usuario.
+  🔴 Se `available` tem match similar → usar o ID dele + description customizada. NAO criar novo servico.
 exec(command="curl -s -X POST -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" -H \"Content-Type: application/json\" -d '{\"customer\":\"Joao\",\"service\":\"tela\"}' \"$PRATICOS_API_URL/bot/search/unified\"")
 
 ## Resumo
@@ -38,6 +41,7 @@ exec(command="curl -s -X PATCH -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsA
 POST /bot/orders/{NUM}/services `{"serviceId":"ID","value":N,"description":"txt","deviceId":"ID"}`
 POST /bot/orders/{NUM}/products `{"productId":"ID","quantity":N,"value":N,"description":"txt","deviceId":"ID"}`
 `deviceId` opcional — vincula item a um dispositivo especifico da OS.
+`description` opcional — texto livre que complementa o nome do servico/produto do catalogo. Usar para especificar detalhes (ex: "Para-lama Esquerdo", "Oleo 5W30", "Split 12k - Sala").
 DELETE /bot/orders/{NUM}/services/{I} | DELETE /bot/orders/{NUM}/products/{I}
 PATCH /bot/orders/{NUM}/customer | PATCH /bot/orders/{NUM}/device
 


### PR DESCRIPTION
## Summary

- **Anti-duplicação de OS**: Adicionada regra explícita no SKILL.md para o bot resolver TODOS os dados (customer, device, serviços) antes de criar uma OS. Se errar, deve usar PATCH para corrigir em vez de criar outra OS.
- **Uso de serviços existentes com description**: Bot agora usa matches do campo `available` da busca unificada com `description` customizada, em vez de criar serviços redundantes no catálogo (ex: usa "Pintura de Para-lama" + description "Esquerdo" em vez de criar "Pintura de Para-lama Esquerdo").
- **Documentação da API**: Campos `results` vs `available` e `description` documentados em api-endpoints.md.

## Test plan

- [ ] `cd backend/bot && make sync` para sincronizar prompts
- [ ] Enviar foto + "cliente X, veículo Y, pintura de parachoque dianteiro" → NÃO deve criar 2 OSes
- [ ] Verificar que usa `description` para especificar detalhes em vez de criar serviço novo
- [ ] Monitorar logs: `POST /bot/entities/services` deve diminuir; não deve haver 2x `POST /bot/orders/full` seguidos

🤖 Generated with [Claude Code](https://claude.com/claude-code)