### PR TITLE
feat(web): use segment-aware labels on share link page

### DIFF
--- a/firebase/functions/src/routes/public/orders.routes.ts
+++ b/firebase/functions/src/routes/public/orders.routes.ts
@@ -17,6 +17,32 @@ import { maskName, maskPhone, maskSerial } from '../../utils/mask.utils';
 const router: Router = Router();
 
 /**
+ * Fetch segment custom labels for the magic link page.
+ * Returns a map like: { 'device._entity': { 'pt-BR': 'Veículo', ... }, ... }
+ */
+async function getSegmentLabels(segmentId?: string): Promise<Record<string, Record<string, string>> | null> {
+  if (!segmentId) return null;
+  try {
+    const segmentDoc = await db.collection('segments').doc(segmentId).get();
+    if (!segmentDoc.exists) return null;
+    const data = segmentDoc.data();
+    const customFields = data?.customFields as Array<{ key: string; type: string; labels: Record<string, string> }> | undefined;
+    if (!customFields?.length) return null;
+
+    const labels: Record<string, Record<string, string>> = {};
+    for (const field of customFields) {
+      if (field.type === 'label' && field.labels) {
+        labels[field.key] = field.labels;
+      }
+    }
+    return Object.keys(labels).length > 0 ? labels : null;
+  } catch (error) {
+    console.error('Failed to fetch segment labels:', error);
+    return null;
+  }
+}
+
+/**
  * GET /public/orders/:token
  * View order details via share token
  */
@@ -110,8 +136,10 @@ router.get('/:token', shareTokenAuth, async (req: AuthenticatedRequest, res: Res
           email: company.email,
           address: company.address,
           country: company.country,
+          segment: company.segment || null,
           termsOfService: company.termsOfService || null,
         } : null,
+        segmentLabels: await getSegmentLabels(company?.segment),
         comments: comments.map((c) => ({
           // IDs removed for LGPD compliance
           text: c.text,

--- a/firebase/web/composables/useOrderI18n.ts
+++ b/firebase/web/composables/useOrderI18n.ts
@@ -318,6 +318,22 @@ const uiStrings: Record<Lang, Record<string, string>> = {
   },
 }
 
+// Map short lang codes to locale codes used in segment customFields
+const langToLocale: Record<Lang, string> = {
+  pt: 'pt-BR',
+  en: 'en-US',
+  es: 'es-ES',
+}
+
+// Segment label keys mapped to i18n keys they override
+const segmentKeyMap: Record<string, keyof typeof uiStrings.pt> = {
+  'device._entity': 'device',
+  'device._entity_plural': 'devices',
+}
+
+// Shared reactive state for segment labels (set once, used by all composable instances)
+const _segmentLabels = ref<Record<string, Record<string, string>> | null>(null)
+
 export function useOrderI18n() {
   // Always start with 'pt' for SSR/client consistency (avoids hydration mismatch)
   const lang = ref<Lang>('pt')
@@ -337,7 +353,25 @@ export function useOrderI18n() {
     })
   }
 
-  const t = computed(() => uiStrings[lang.value] || uiStrings.pt)
+  const t = computed(() => {
+    const base = { ...(uiStrings[lang.value] || uiStrings.pt) }
+    const labels = _segmentLabels.value
+    if (labels) {
+      const locale = langToLocale[lang.value]
+      for (const [segKey, uiKey] of Object.entries(segmentKeyMap)) {
+        const label = labels[segKey]?.[locale]
+        if (label) {
+          (base as any)[uiKey] = label
+        }
+      }
+      // Also override 'vehicles' with device plural label when available
+      const devicePlural = labels['device._entity_plural']?.[locale]
+      if (devicePlural) {
+        base.vehicles = devicePlural
+      }
+    }
+    return base
+  })
   const status = computed(() => statusLabels[lang.value] || statusLabels.pt)
 
   function setLang(newLang: Lang) {
@@ -349,9 +383,13 @@ export function useOrderI18n() {
     }
   }
 
+  function setSegmentLabels(labels: Record<string, Record<string, string>> | null) {
+    _segmentLabels.value = labels
+  }
+
   function getStatusLabel(statusKey: string): string {
     return status.value[statusKey] || statusKey
   }
 
-  return { lang, t, status, setLang, getStatusLabel }
+  return { lang, t, status, setLang, setSegmentLabels, getStatusLabel }
 }

--- a/firebase/web/pages/q/[token].vue
+++ b/firebase/web/pages/q/[token].vue
@@ -149,7 +149,7 @@
 const route = useRoute()
 const token = route.params.token as string
 
-const { t } = useOrderI18n()
+const { t, setSegmentLabels } = useOrderI18n()
 const { approveQuote, rejectQuote } = useOrderApi()
 
 // SSR data fetch via server proxy
@@ -160,6 +160,10 @@ const order = computed(() => (orderData.value as any)?.data?.order)
 const company = computed(() => (orderData.value as any)?.data?.company)
 const comments = computed(() => (orderData.value as any)?.data?.comments || [])
 const permissions = computed(() => (orderData.value as any)?.data?.permissions || [])
+
+// Apply segment custom labels (e.g. "Veículos" for automotive, "Aparelhos" for electronics)
+const segmentLabels = computed(() => (orderData.value as any)?.data?.segmentLabels || null)
+watch(segmentLabels, (labels) => setSegmentLabels(labels), { immediate: true })
 
 // SEO meta - noindex for share links
 useHead({


### PR DESCRIPTION
## Summary
- Labels como "Veículos", "Equipamentos", "Dispositivo" na página de acompanhamento (magic link) agora são dinâmicos baseados no segmento da empresa
- Backend busca `customFields` do segmento no Firestore e retorna `segmentLabels` na API pública
- Frontend sobrescreve labels padrão do i18n com os labels do segmento

### Exemplos por segmento
| Segmento | Label anterior | Label agora |
|----------|---------------|-------------|
| Automotivo | Equipamentos | Veículos |
| Eletrônica | Equipamentos | Aparelhos |
| Informática | Equipamentos | Computadores |
| Eletrodomésticos | Equipamentos | Eletrodomésticos |
| HVAC | Equipamentos | Instalações |
| Sem segmento | Equipamentos | Equipamentos (fallback) |

## Test plan
- [ ] Acessar share link de empresa com segmento `automotive` → label deve ser "Veículos"
- [ ] Acessar share link de empresa com segmento `electronics` → label deve ser "Aparelhos"
- [ ] Acessar share link de empresa sem segmento → label deve ser "Equipamentos" (fallback)
- [ ] Trocar idioma (en/es) → labels devem traduzir corretamente ("Vehicles", "Vehículos")
- [ ] Verificar que não quebra a página quando `segmentLabels` é null

🤖 Generated with [Claude Code](https://claude.com/claude-code)