### PR TITLE
fix(android): botão WhatsApp não funciona no Android 11+

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -81,5 +81,10 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- Required for url_launcher to open https links (WhatsApp, etc.) on Android 11+ -->
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
+        </intent>
     </queries>
 </manifest>

--- a/lib/screens/menu_navigation/widgets/link_whatsapp_sheet.dart
+++ b/lib/screens/menu_navigation/widgets/link_whatsapp_sheet.dart
@@ -77,9 +77,7 @@ class _LinkWhatsAppSheetState extends State<LinkWhatsAppSheet> {
 
   Future<void> _openWhatsApp(String link) async {
     final uri = Uri.parse(link);
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
   }
 
   @override


### PR DESCRIPTION
## Resumo
- Adiciona declaração `<queries>` para scheme `https` no `AndroidManifest.xml`, necessária no Android 11+ (API 30+) para que o `url_launcher` consiga abrir links externos (WhatsApp, etc.)
- Remove guard `canLaunchUrl` desnecessário que causava falha silenciosa no Android quando as queries não estavam declaradas

## Plano de teste
- [ ] Build e rodar em dispositivo/emulador Android (API 30+)
- [ ] Tocar no botão "Vincular com WhatsApp" e confirmar que o WhatsApp abre
- [ ] Verificar que iOS continua funcionando normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)