### PR TITLE
fix(android): add ProGuard rules for flutter_local_notifications Gson crash

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,16 @@
+## Gson rules (required by flutter_local_notifications)
+-keepattributes Signature
+-keepattributes *Annotation*
+-dontwarn sun.misc.**
+
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken

--- a/android/app/src/main/res/raw/keep.xml
+++ b/android/app/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/*,@mipmap/*" />


### PR DESCRIPTION
## Summary
- Cria `proguard-rules.pro` que estava referenciado no `build.gradle.kts` mas não existia, causando crash no boot do dispositivo quando o `ScheduledNotificationBootReceiver` tentava restaurar notificações agendadas
- Adiciona regras Gson/TypeToken para evitar que o R8 remova assinaturas genéricas usadas pelo `flutter_local_notifications`
- Adiciona `keep.xml` preventivo para proteger drawables/mipmaps de notificação do resource shrinking

## Test plan
- [x] Build release Android passa sem erros de ProGuard
- [ ] Agendar notificação, reiniciar dispositivo, verificar que não há crash
- [ ] Verificar que ícones de notificação aparecem corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)