### PR TITLE
chore(ci): inject RevenueCat API keys into build pipeline

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -112,6 +112,7 @@ jobs:
         env:
           FASTLANE_SKIP_UPDATE_CHECK: "true"
           CI: "true"
+          REVENUECAT_ANDROID_API_KEY: ${{ secrets.REVENUECAT_ANDROID_API_KEY }}
         run: bundle exec fastlane internal
 
       # 📦 Upload AAB to GitHub Release

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -170,6 +170,7 @@ jobs:
           DEVELOPMENT_TEAM: ${{ env.DEVELOPMENT_TEAM }}
           PROFILE_UUID: ${{ env.PROFILE_UUID }}
           PROFILE_NAME: ${{ env.PROFILE_NAME }}
+          REVENUECAT_IOS_API_KEY: ${{ secrets.REVENUECAT_IOS_API_KEY }}
           FASTLANE_SKIP_UPDATE_CHECK: "true"
           CI: "true"
         run: bundle exec fastlane beta

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -10,11 +10,15 @@ platform :android do
   lane :build_flutter do |options|
     version_code = options[:version_code]
     version_name = options[:version_name]
-    
+
     # Constrói o comando flutter build
     build_args = ["build", "appbundle", "--release"]
     build_args << "--build-number=#{version_code}" if version_code
     build_args << "--build-name=#{version_name}" if version_name
+
+    # RevenueCat API key (injected via CI secret REVENUECAT_ANDROID_API_KEY)
+    revenuecat_key = ENV['REVENUECAT_ANDROID_API_KEY']
+    build_args << "--dart-define=REVENUECAT_ANDROID_API_KEY=#{revenuecat_key}" if revenuecat_key && !revenuecat_key.empty?
 
     # Executa o build do Flutter na raiz do projeto (../)
     Dir.chdir("..") do

--- a/docs/ANDROID_GITHUB_SECRETS.md
+++ b/docs/ANDROID_GITHUB_SECRETS.md
@@ -28,6 +28,18 @@ All files must be encoded in Base64 before adding them as secrets.
     base64 -i android/app/google-services.json | pbcopy
     ```
 
+### 4. `REVENUECAT_ANDROID_API_KEY`
+*   **Source:** RevenueCat dashboard → Project Settings → API Keys → Public SDK Key (Android)
+*   **Format:** Plain text (e.g., `goog_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`)
+*   **Used for:** Subscription management via RevenueCat SDK (`purchases_flutter`)
+*   **Note:** If not set, RevenueCat will not initialize and all users will be on the Free plan.
+
+### 5. `REVENUECAT_IOS_API_KEY` *(iOS workflow)*
+*   **Source:** RevenueCat dashboard → Project Settings → API Keys → Public SDK Key (iOS)
+*   **Format:** Plain text (e.g., `appl_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`)
+*   **Used for:** Subscription management via RevenueCat SDK on iOS builds
+*   **Note:** Add this secret to the iOS workflow (`ios_release.yml`) as well.
+
 ## Workflow Behavior
 
 *   **Push to `master`:** Triggers `fastlane internal` (Builds AAB & uploads to Internal Test Track).

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -51,8 +51,12 @@ platform :ios do
     UI.message("Current build: #{current_build}, Next build: #{next_build}")
 
     # 🏗️ Flutter build com build number correto (sem code sign)
+    flutter_build_args = ["flutter", "build", "ios", "--release", "--no-codesign", "--build-number=#{next_build}"]
+    revenuecat_key = ENV['REVENUECAT_IOS_API_KEY']
+    flutter_build_args << "--dart-define=REVENUECAT_IOS_API_KEY=#{revenuecat_key}" if revenuecat_key && !revenuecat_key.empty?
+
     Dir.chdir("..") do
-      sh("flutter", "build", "ios", "--release", "--no-codesign", "--build-number=#{next_build}")
+      sh(*flutter_build_args)
     end
 
     # 🔧 força assinatura só no Runner (Release)
@@ -135,8 +139,12 @@ platform :ios do
     UI.message("Current build: #{current_build}, Next build: #{next_build}")
 
     # 🏗️ Flutter build com build number correto (sem code sign)
+    flutter_build_args = ["flutter", "build", "ios", "--release", "--no-codesign", "--build-number=#{next_build}"]
+    revenuecat_key = ENV['REVENUECAT_IOS_API_KEY']
+    flutter_build_args << "--dart-define=REVENUECAT_IOS_API_KEY=#{revenuecat_key}" if revenuecat_key && !revenuecat_key.empty?
+
     Dir.chdir("..") do
-      sh("flutter", "build", "ios", "--release", "--no-codesign", "--build-number=#{next_build}")
+      sh(*flutter_build_args)
     end
 
     # 🔧 força assinatura só no Runner (Release)


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `String.fromEnvironment('REVENUECAT_*_API_KEY')` silently returns `''` when `--dart-define` is not passed — RevenueCat skips initialization and all users appear on Free plan in production builds
- Android `Fastfile`: `build_flutter` lane reads `REVENUECAT_ANDROID_API_KEY` env var and appends `--dart-define` only when non-empty (safe fallback)
- iOS `Fastfile`: `beta` and `release_store` lanes read `REVENUECAT_IOS_API_KEY` and pass it the same way
- `android_release.yml`: forwards `secrets.REVENUECAT_ANDROID_API_KEY` to Fastlane env block
- `ios_release.yml`: forwards `secrets.REVENUECAT_IOS_API_KEY` to Fastlane beta env block
- `docs/ANDROID_GITHUB_SECRETS.md`: documents both new secrets with source URL, format example, and silent-failure warning

## Required GitHub Secrets

Before merging, add these to **Settings → Secrets → Actions**:

| Secret | Source |
|--------|--------|
| `REVENUECAT_ANDROID_API_KEY` | RevenueCat Dashboard → Project Settings → API Keys → Public SDK Key (Android) |
| `REVENUECAT_IOS_API_KEY` | RevenueCat Dashboard → Project Settings → API Keys → Public SDK Key (iOS) |

## Test plan

- [ ] Add both secrets to GitHub repository settings
- [ ] Trigger `android_release` workflow — verify build succeeds and RevenueCat initializes (check logs for `RevenueCat configured`)
- [ ] Trigger `ios_release` workflow — verify beta lane succeeds with RC key in flutter build args
- [ ] Builds without the secret set should still succeed (conditional append guards against empty key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)