### PR TITLE
chore(ci): update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/android_build_check.yml
+++ b/.github/workflows/android_build_check.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -41,7 +41,7 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "📌 Using tag: $TAG"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ steps.get_tag.outputs.tag }}
 
@@ -60,7 +60,7 @@ jobs:
 
       # Setup Java
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -34,7 +34,7 @@ jobs:
       bump_type: ${{ steps.analyze.outputs.bump_type }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/bot-sync.yml
+++ b/.github/workflows/bot-sync.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_PRATICOS }}'
 
       - name: Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: praticos
 

--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -14,15 +14,15 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_PRATICOS }}'
 
       - name: Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: praticos
 

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/firebase-functions-deploy.yml
+++ b/.github/workflows/firebase-functions-deploy.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -33,7 +33,7 @@ jobs:
         run: npm run lint || true
 
       - name: Authenticate to Firebase
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_PRATICOS }}'
 
@@ -41,7 +41,7 @@ jobs:
         run: npm install -g firebase-tools
 
       - name: Install gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Enable required GCP APIs
         run: |

--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/ios_build_check.yml
+++ b/.github/workflows/ios_build_check.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: macos-14
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Flutter
         uses: subosito/flutter-action@v2
@@ -35,7 +35,7 @@ jobs:
           cache: true
 
       - name: Cache Pub deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
@@ -73,7 +73,7 @@ jobs:
           echo "✅ GoogleService-Info.plist criado"
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ios/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -43,7 +43,7 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "📌 Using tag: $TAG"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ steps.get_tag.outputs.tag }}
 
@@ -69,7 +69,7 @@ jobs:
           cache: true # Ativa o cache do SDK
 
       - name: Cache Pub deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
@@ -105,7 +105,7 @@ jobs:
 
       # 🔐 Importa o certificado .p12 no keychain
       - name: Import distribution cert
-        uses: apple-actions/import-codesign-certs@v2
+        uses: apple-actions/import-codesign-certs@v3
         with:
           p12-file-base64: ${{ secrets.IOS_DIST_CERTIFICATE_BASE64 }}
           p12-password: ${{ secrets.IOS_DIST_CERTIFICATE_PASSWORD }}
@@ -131,7 +131,7 @@ jobs:
           echo "Using profile: $NAME (UUID $UUID) - TEAM $TEAM"
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ios/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.validate.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -87,13 +87,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       # Check for Metadata/Screenshot changes since RC tag
       - name: Check for metadata changes
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           base: ${{ needs.validate.outputs.rc_tag }}
@@ -157,13 +157,13 @@ jobs:
       BUNDLE_ID: br.com.rafsoft.praticos
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       # Check for Metadata/Screenshot changes since RC tag
       - name: Check for metadata changes
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           base: ${{ needs.validate.outputs.rc_tag }}
@@ -228,7 +228,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Contexto

GitHub está depreciando Node.js 20 nas Actions a partir de **02/06/2026**. Após essa data, os runners forçarão Node.js 24 como padrão, podendo quebrar actions que não foram atualizadas.

Este PR atualiza todas as actions afetadas de forma preventiva.

## Actions Atualizadas

| Action | Antes | Depois |
|--------|-------|--------|
| `actions/checkout` | v4 | v5 |
| `actions/cache` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/setup-java` | v4 | v5 |
| `google-github-actions/auth` | v2 | v3 |
| `google-github-actions/setup-gcloud` | v2 | v3 |
| `apple-actions/import-codesign-certs` | v2 | v3 |
| `dorny/paths-filter` | v2 | v4 |

## Workflows Afetados

11 arquivos: `android_build_check`, `android_release`, `auto-version`, `bot-sync`, `cloud-run-deploy`, `code_quality`, `firebase-functions-deploy`, `firebase-hosting-deploy`, `ios_build_check`, `ios_release`, `promote-release`

## Actions Não Alteradas

- `ruby/setup-ruby@v1` — já compatível com Node.js 24
- `subosito/flutter-action@v2` — já compatível
- `maxim-lobanov/setup-xcode@v1` — já compatível
- `softprops/action-gh-release@v2` — já na versão correta
- `actions/upload-artifact@v4` — v7 disponível mas v4 ainda suportado; atualização opcional futura
- `FirebaseExtended/action-hosting-deploy@v0` — sem releases mais novos disponíveis

## Test plan

- [ ] Verificar que `android_build_check` passa após merge
- [ ] Verificar que `ios_build_check` passa após merge
- [ ] Verificar que `code_quality` passa após merge
- [ ] Disparar `Deploy Firebase Functions` via workflow_dispatch e confirmar sucesso

🤖 Generated with [Claude Code](https://claude.com/claude-code)