### PR TITLE
fix(subscription): corrigir tratamento de erros no checkout de plano (PRA-53)

### DIFF
--- a/lib/mobx/subscription_store.dart
+++ b/lib/mobx/subscription_store.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:mobx/mobx.dart';
 import 'package:purchases_flutter/purchases_flutter.dart' hide Store;
 import 'package:praticos/services/subscription_service.dart';
@@ -154,12 +155,14 @@ abstract class _SubscriptionStore with Store {
     try {
       customerInfo = await _service.purchasePackage(package);
       return true;
-    } on PurchasesErrorCode catch (e) {
-      if (e == PurchasesErrorCode.purchaseCancelledError) {
+    } on PlatformException catch (e) {
+      final errorCode = PurchasesErrorHelper.getErrorCode(e);
+      if (errorCode == PurchasesErrorCode.purchaseCancelledError) {
         // Usuario cancelou, nao e um erro
         debugPrint('SubscriptionStore: Purchase cancelled by user');
         return false;
       }
+      debugPrint('SubscriptionStore: Purchase error: $errorCode - ${e.message}');
       errorMessage = 'Erro ao processar compra. Tente novamente.';
       return false;
     } catch (e, stack) {

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -144,7 +144,8 @@ class SubscriptionService {
   /// [package] - Pacote a ser comprado (obtido via getOfferings)
   /// Retorna [CustomerInfo] atualizado apos a compra.
   ///
-  /// Throws [PurchasesErrorCode.purchaseCancelledError] se o usuario cancelar.
+  /// Throws [PlatformException] se ocorrer um erro ou cancelamento.
+  /// Use [PurchasesErrorHelper.getErrorCode] para verificar o tipo de erro.
   Future<CustomerInfo> purchasePackage(Package package) async {
     try {
       debugPrint('SubscriptionService: Purchasing package ${package.identifier}');

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -1,5 +1,6 @@
 import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 
@@ -150,7 +151,7 @@ class SubscriptionService {
       final customerInfo = await Purchases.purchasePackage(package);
       debugPrint('SubscriptionService: Purchase successful');
       return customerInfo;
-    } on PurchasesErrorCode catch (e) {
+    } on PlatformException catch (e) {
       debugPrint('SubscriptionService: Purchase error: $e');
       rethrow;
     }


### PR DESCRIPTION
## Summary

- Corrige bug no checkout onde o catch capturava `PurchasesErrorCode` diretamente, mas a SDK RevenueCat lança `PlatformException`
- Usa `PurchasesErrorHelper.getErrorCode()` para extrair o código de erro correto da `PlatformException`
- Adiciona logging melhorado para diagnóstico de erros de compra

## Arquivos alterados

- `lib/mobx/subscription_store.dart` - Fix do catch + import PlatformException
- `lib/services/subscription_service.dart` - Fix do catch + docstring atualizada

## Test plan

- [ ] QA: Testar fluxo de compra de plano (selecionar plano -> checkout)
- [ ] QA: Verificar que cancelamento pelo usuário não mostra mensagem de erro
- [ ] QA: Verificar que erros reais mostram mensagem "Erro ao processar compra"
- [ ] QA: Validar em sandbox iOS e Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)