### PR TITLE
fix(pdf): resolve TooManyPagesException on PDF generation

### DIFF
--- a/lib/services/pdf/pdf_main_os_builder.dart
+++ b/lib/services/pdf/pdf_main_os_builder.dart
@@ -954,26 +954,22 @@ class PdfMainOsBuilder {
 
   /// Constrói a marca d'água "PraticOS" rotacionada 45 graus.
   ///
-  /// A marca d'água é sobreposta em todas as páginas quando [showWatermark] é true.
-  /// Usa opacidade de 8% para não atrapalhar a leitura do documento.
+  /// Projetado para uso via `pageTheme.buildForeground` do MultiPage,
+  /// renderizado como overlay sem afetar a paginacao.
   pw.Widget buildWatermark() {
     if (!showWatermark) return pw.SizedBox();
 
-    return pw.FullPage(
-      ignoreMargins: true,
-      child: pw.Center(
-        child: pw.Transform.rotate(
-          angle: -0.785398, // -45 graus em radianos
-          child: pw.Opacity(
-            opacity: 0.08,
-            child: pw.Text(
-              'PraticOS',
-              style: pw.TextStyle(
-                font: boldFont,
-                fontSize: 72,
-                color: PdfColors.grey,
-              ),
-            ),
+    return pw.Watermark(
+      angle: -0.785398, // -45 graus
+      fit: pw.BoxFit.none,
+      child: pw.Opacity(
+        opacity: 0.06,
+        child: pw.Text(
+          'PraticOS',
+          style: pw.TextStyle(
+            font: boldFont,
+            fontSize: 72,
+            color: PdfColors.grey,
           ),
         ),
       ),

--- a/lib/services/pdf/pdf_service.dart
+++ b/lib/services/pdf/pdf_service.dart
@@ -112,8 +112,13 @@ class PdfService {
     if (options.includeMainOs) {
       doc.addPage(
         pw.MultiPage(
-          pageFormat: PdfStyles.pageFormat,
-          margin: PdfStyles.pageMargin,
+          pageTheme: pw.PageTheme(
+            pageFormat: PdfStyles.pageFormat,
+            margin: PdfStyles.pageMargin,
+            buildForeground: showWatermark
+                ? (_) => mainOsBuilder.buildWatermark()
+                : null,
+          ),
           header: (pw.Context context) {
             return mainOsBuilder.buildHeader(data.company, data.order);
           },
@@ -121,16 +126,11 @@ class PdfService {
             return mainOsBuilder.buildFooter(context);
           },
           build: (pw.Context context) {
-            final content = mainOsBuilder.buildContent(
+            return mainOsBuilder.buildContent(
               order: data.order,
               customer: data.customer,
               company: data.company,
             );
-            // Adicionar marca d'agua como primeiro widget (background)
-            if (showWatermark) {
-              return [mainOsBuilder.buildWatermark(), ...content];
-            }
-            return content;
           },
         ),
       );
@@ -143,8 +143,13 @@ class PdfService {
 
         doc.addPage(
           pw.MultiPage(
-            pageFormat: PdfStyles.pageFormat,
-            margin: PdfStyles.pageMargin,
+            pageTheme: pw.PageTheme(
+              pageFormat: PdfStyles.pageFormat,
+              margin: PdfStyles.pageMargin,
+              buildForeground: showWatermark
+                  ? (_) => mainOsBuilder.buildWatermark()
+                  : null,
+            ),
             footer: (pw.Context context) {
               return formsBuilder.buildFormFooter(
                 context,
@@ -155,17 +160,12 @@ class PdfService {
               );
             },
             build: (pw.Context context) {
-              final content = formsBuilder.buildFormContent(
+              return formsBuilder.buildFormContent(
                 company: data.company,
                 order: data.order,
                 form: form,
                 itemPhotosMap: itemPhotosMap,
               );
-              // Adicionar marca d'agua nas paginas de formularios tambem
-              if (showWatermark) {
-                return [mainOsBuilder.buildWatermark(), ...content];
-              }
-              return content;
             },
           ),
         );


### PR DESCRIPTION
## Summary
- `FullPage` widget usado como watermark dentro de `MultiPage.build()` reportava altura A4 completa (842pt), mas header/footer reduziam o espaço disponível, causando loop infinito de paginação → `TooManyPagesException`
- Movido watermark para `pageTheme.buildForeground`, que renderiza como overlay sem afetar o fluxo de paginação
- Ajustada opacidade da watermark para 6% e `BoxFit.none` para manter tamanho fixo

## Test plan
- [x] Abrir OS no simulador e gerar PDF — sem crash
- [x] Verificar watermark sutil no PDF (conta Free)
- [x] Verificar formulários com watermark
- [x] Verificar PDF sem watermark (conta paga)

🤖 Generated with [Claude Code](https://claude.com/claude-code)