### PR TITLE
ci(hosting): trigger deploy on firebase.json changes

### DIFF
--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -7,7 +7,8 @@ on:
     branches:
       - master  # Ou a branch que você usa como principal
     paths:
-      - 'firebase/hosting/**' # Executa a action apenas se houver mudanças na pasta do site
+      - 'firebase/hosting/**' # Executa a action se houver mudanças na pasta do site
+      - 'firebase/firebase.json' # Ou se mudar rewrites/headers/config do hosting
 
 jobs:
   build_and_deploy:

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -59,6 +59,13 @@
         }
       },
       {
+        "source": "/admin",
+        "run": {
+          "serviceId": "praticos-web",
+          "region": "southamerica-east1"
+        }
+      },
+      {
         "source": "/admin/**",
         "run": {
           "serviceId": "praticos-web",


### PR DESCRIPTION
## Summary
- Adiciona `firebase/firebase.json` ao filtro de paths da action de hosting deploy, para que alterações em rewrites/headers sejam deployadas automaticamente
- Adiciona rewrite exato `/admin` (sem trailing slash) para o Cloud Run, resolvendo 404 ao acessar `praticos.web.app/admin`

## Test plan
- [ ] Verificar que `praticos.web.app/admin` (sem /) carrega corretamente
- [ ] Verificar que alterações em `firebase/firebase.json` disparam a action de hosting deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)