### PR TITLE
feat(admin): add lastOrderDate and fix retention/revenue

### DIFF
--- a/firebase/functions/scripts/backfill-last-order-date.ts
+++ b/firebase/functions/scripts/backfill-last-order-date.ts
@@ -1,0 +1,99 @@
+/**
+ * Backfill lastOrderDate Script
+ * Sets the `lastOrderDate` field on all company documents based on their most recent order.
+ *
+ * Usage (production - uses default credentials):
+ *   npx ts-node scripts/backfill-last-order-date.ts
+ *
+ * Usage (emulator):
+ *   FIRESTORE_EMULATOR_HOST=localhost:8080 npx ts-node scripts/backfill-last-order-date.ts
+ *
+ * Dry run (no writes):
+ *   npx ts-node scripts/backfill-last-order-date.ts --dry-run
+ */
+
+import * as admin from 'firebase-admin';
+
+admin.initializeApp();
+
+const db = admin.firestore();
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function backfillLastOrderDate() {
+  console.log(`\n🔄 Backfill lastOrderDate ${DRY_RUN ? '(DRY RUN)' : ''}\n`);
+
+  const companiesSnap = await db.collection('companies').get();
+  console.log(`Found ${companiesSnap.size} companies\n`);
+
+  let updated = 0;
+  let skipped = 0;
+  let noOrders = 0;
+  let errors = 0;
+
+  for (const companyDoc of companiesSnap.docs) {
+    try {
+      const companyData = companyDoc.data();
+      const companyName = companyData.name || companyDoc.id;
+
+      // Get most recent order
+      const ordersSnap = await db
+        .collection(`companies/${companyDoc.id}/orders`)
+        .orderBy('createdAt', 'desc')
+        .limit(1)
+        .get();
+
+      if (ordersSnap.empty) {
+        noOrders++;
+        continue;
+      }
+
+      const latestOrder = ordersSnap.docs[0].data();
+      const lastOrderDate = latestOrder.createdAt;
+
+      if (!lastOrderDate) {
+        console.log(`  ⚠ ${companyName}: latest order has no createdAt`);
+        skipped++;
+        continue;
+      }
+
+      // Check if already has lastOrderDate and is up-to-date
+      if (companyData.lastOrderDate) {
+        const existing = companyData.lastOrderDate.toDate
+          ? companyData.lastOrderDate.toDate()
+          : new Date(companyData.lastOrderDate);
+        const newDate = lastOrderDate.toDate
+          ? lastOrderDate.toDate()
+          : new Date(lastOrderDate);
+
+        if (existing >= newDate) {
+          skipped++;
+          continue;
+        }
+      }
+
+      if (!DRY_RUN) {
+        await companyDoc.ref.update({ lastOrderDate });
+      }
+
+      console.log(`  ✅ ${companyName}: lastOrderDate set`);
+      updated++;
+    } catch (err: any) {
+      console.error(`  ❌ ${companyDoc.id}: ${err.message}`);
+      errors++;
+    }
+  }
+
+  console.log(`\n📊 Results:`);
+  console.log(`  Updated: ${updated}`);
+  console.log(`  Skipped (already up-to-date): ${skipped}`);
+  console.log(`  No orders: ${noOrders}`);
+  console.log(`  Errors: ${errors}`);
+  console.log(`  Total: ${companiesSnap.size}\n`);
+}
+
+backfillLastOrderDate()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -53,7 +53,10 @@ export const firestoreUpdateTenantOSNumber = functionsV1
       const currentNumber = companyData?.nextOrderNumber || 1;
 
       transaction.update(orderRef, { number: currentNumber });
-      transaction.update(companyRef, { nextOrderNumber: currentNumber + 1 });
+      transaction.update(companyRef, {
+        nextOrderNumber: currentNumber + 1,
+        lastOrderDate: data.createdAt || admin.firestore.FieldValue.serverTimestamp(),
+      });
 
       console.log(`OS #${currentNumber} assigned to order ${orderRef.id} of company ${companyId}`);
     });

--- a/firebase/web/server/api/admin/companies.get.ts
+++ b/firebase/web/server/api/admin/companies.get.ts
@@ -14,7 +14,7 @@ export default defineEventHandler(async (event) => {
   if (!allData) {
     const db = getAdminDb()
     const now = new Date()
-    const monthAgo = new Date(now.getTime() - 30 * 86400000)
+    const activeWindowStart = new Date(now.getTime() - 7 * 86400000) // active = OS in last 7 days
 
     const [ordersSnap, companiesSnap] = await Promise.all([
       db.collectionGroup('orders').orderBy('createdAt', 'desc').limit(10000).get(),
@@ -48,8 +48,9 @@ export default defineEventHandler(async (event) => {
     allData = companiesSnap.docs.map((doc) => {
       const d = doc.data()
       const stats = companyOrderStats.get(doc.id)
-      const lastOrderDate = stats?.lastOrderDate || null
-      const isActive = lastOrderDate ? new Date(lastOrderDate) >= monthAgo : false
+      // Prefer lastOrderDate from company doc (set by trigger), fallback to orders scan
+      const lastOrderDate = parseFirestoreDate(d.lastOrderDate)?.toISOString() || stats?.lastOrderDate || null
+      const isActive = lastOrderDate ? new Date(lastOrderDate) >= activeWindowStart : false
 
       return {
         id: doc.id,

--- a/firebase/web/server/api/admin/overview.get.ts
+++ b/firebase/web/server/api/admin/overview.get.ts
@@ -57,6 +57,7 @@ export default defineEventHandler(async (event) => {
       country: d.country as string | undefined,
       membersCount: Array.isArray(d.users) ? d.users.length : 0,
       createdAt: parseFirestoreDate(d.createdAt),
+      lastOrderDate: parseFirestoreDate(d.lastOrderDate),
       nextOrderNumber: (d.nextOrderNumber as number) || 0,
     }
   })
@@ -70,20 +71,21 @@ export default defineEventHandler(async (event) => {
   // --- PERIOD-FILTERED orders (everything below uses this) ---
   const periodOrders = allOrders.filter((o) => o.effectiveDate && o.effectiveDate >= periodStart)
 
-  // Active companies (had orders in period)
+  // Active companies = had at least 1 OS in the last 7 days (using lastOrderDate from company doc)
+  const ACTIVE_WINDOW_DAYS = 7
+  const activeWindowStart = new Date(now.getTime() - ACTIVE_WINDOW_DAYS * 86400000)
   const activeCompanyIds = new Set(
-    periodOrders.filter((o) => o.companyId).map((o) => o.companyId),
+    companies
+      .filter((c) => c.lastOrderDate && c.lastOrderDate >= activeWindowStart)
+      .map((c) => c.id),
   )
 
-  // Retention: active in period vs active in previous equivalent period
-  const prevPeriodStart = new Date(periodStart.getTime() - periodDays * 86400000)
-  const prevPeriodActiveIds = new Set(
-    allOrders
-      .filter((o) => o.effectiveDate && o.effectiveDate >= prevPeriodStart && o.effectiveDate < periodStart && o.companyId)
-      .map((o) => o.companyId),
-  )
-  const retentionRate = prevPeriodActiveIds.size > 0
-    ? Math.round((activeCompanyIds.size / prevPeriodActiveIds.size) * 100)
+  // Retention: of companies registered in the selected period, how many are still active?
+  // "Active" = created at least 1 OS in the last 7 days (lastOrderDate >= 7 days ago)
+  const companiesInPeriod = companies.filter((c) => c.createdAt && c.createdAt >= periodStart)
+  const retainedCount = companiesInPeriod.filter((c) => activeCompanyIds.has(c.id)).length
+  const retentionRate = companiesInPeriod.length > 0
+    ? Math.round((retainedCount / companiesInPeriod.length) * 100)
     : 0
 
   // Orders by status (period-filtered)


### PR DESCRIPTION
## Summary
- Adiciona campo `lastOrderDate` no doc da company, atualizado atomicamente no trigger de criação de OS
- Retenção corrigida: das empresas cadastradas no período, quantas ainda estão ativas (OS nos últimos 7d)
- Receita inclui todas as OS não canceladas com valor (antes só contava status `done`)
- Dashboard de empresas usa `lastOrderDate` do doc para determinar status ativo
- Script de backfill para popular `lastOrderDate` nas companies existentes (já executado)

## Test plan
- [ ] Verificar retenção muda conforme período selecionado
- [ ] Verificar receita e ticket médio calculando corretamente
- [ ] Verificar badge ativa/inativa na lista de empresas (ativa = OS nos últimos 7d)
- [ ] Criar OS de teste e verificar que `lastOrderDate` é atualizado na company

🤖 Generated with [Claude Code](https://claude.com/claude-code)