### PR TITLE
fix(bot): vincular device em OS via find-or-create quando bot envia inline

### DIFF
--- a/backend/bot/workspace/SOUL.md
+++ b/backend/bot/workspace/SOUL.md
@@ -119,6 +119,7 @@ Responder quando mencionado ou pode adicionar valor. Silêncio (HEARTBEAT_OK) em
 ## Limites
 
 - Nunca invento dados — sempre consulto API
+- 🔴 NUNCA afirmar que uma correção foi feita sem confirmação no response da API. Se a chamada retornou NOT_FOUND/erro/`success:false` → admitir ao usuario que o endpoint falhou e que vou investigar; NUNCA dizer "ja corrigi", "ja vinculei", "ja ajustei" sem ter response 200 + dados batendo.
 - NOT_FOUND → releio SKILL.md. Max 3 tentativas.
 - 🔴 {NUMERO} = origin.from. FIXO. Em cron: leio memória, uso sessions_send (NUNCA message()).
 - Dados sigilosos ficam sigilosos. Ações destrutivas só com confirmação.

--- a/backend/bot/workspace/skills/praticos/SKILL.md
+++ b/backend/bot/workspace/skills/praticos/SKILL.md
@@ -76,6 +76,12 @@ message(filePath="/tmp/os-{NUM}.jpg", message="{card}")
    🔴 NUNCA fazer multiplos /search/unified sequenciais. UMA chamada com todos os termos.
 2. **Criar OS:** busca (1 call com arrays) → IDs → POST /bot/orders/full.
    Apos criar → OS ativa. Adicionar item: se ha OS ativa, usar /services ou /products. So criar nova se pedido explicitamente.
+   🔴 **PLACA LIDA DE FOTO (segmento automotivo):**
+   a) SEMPRE chamar /bot/search/unified com `deviceSerial:"<placa>"` antes de criar a OS.
+   b) Se `device.exact` ou `device.suggestions[].serial` bater com a placa → usar `deviceId` desse resultado em /orders/full.
+   c) Se NAO bateu → passar `device:{name:"<Marca Modelo>", serial:"<placa>", brand:"<Marca>", model:"<Modelo>"}` inline em /orders/full. A API resolve via find-or-create automaticamente.
+   d) Para corrigir uma OS sem placa: PATCH /bot/orders/{NUM}/device com `{"deviceId":"ID"}` OU `{"device":{...}}` inline. Mesma logica de find-or-create.
+   🔴 NUNCA inventar endpoint para "vincular placa" depois (ex: /update-device, /orders/id, /bot/orders/{NUM}/update-device). Eles NAO existem. Use SOMENTE PATCH /bot/orders/{NUM}/device.
 3. **CRUD:** buscar primeiro, confirmar editar/excluir. Criar CLIENTE: pedir contato WhatsApp (vCard). ⚠️ Telefone do vCard = dado do CLIENTE (campo `phone`). NUNCA usar como {NUMERO}.
 4. **Fotos:** upload multipart: `curl -s -X POST -H "X-API-Key: $PRATICOS_API_KEY" -H "X-WhatsApp-Number: {NUMERO}" -F "file=@/path/to/photo.jpg" "$PRATICOS_API_URL/bot/orders/{NUM}/photos/upload"`
    Multiplas fotos: uma chamada por foto. Listar: GET /photos. Deletar: DELETE /photos/{ID}.

--- a/backend/bot/workspace/skills/praticos/references/api-endpoints.md
+++ b/backend/bot/workspace/skills/praticos/references/api-endpoints.md
@@ -31,8 +31,10 @@ exec(command="curl -s -X PATCH -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsA
 
 ## OS - Criar
 POST /bot/orders/full
-Body: {customerId, deviceId?, deviceIds?:["id1","id2"], services:[{serviceId,value?,description?,deviceId?}], products:[{productId,quantity?,value?,description?,deviceId?}], dueDate?, scheduledDate?}
+Body: {customerId, deviceId?, deviceIds?:["id1","id2"], device?:{name?,serial?,brand?,model?}, services:[{serviceId,value?,description?,deviceId?}], products:[{productId,quantity?,value?,description?,deviceId?}], dueDate?, scheduledDate?}
 `deviceIds` para multi-device. Se passado, ignora `deviceId`. Cada service/product pode ter `deviceId` para vincular ao dispositivo.
+🔴 PREFERIR `deviceId` resolvido via /bot/search/unified. Só usar `device:{}` inline quando NAO ha match em search/unified E voce acabou de ler dados novos (ex: placa lida de foto). A API faz find-or-create automaticamente por serial→nome.
+🔴 NUNCA passar `device:{}` quando search/unified retornou `exact` ou `suggestions[].serial` igual a placa lida — usar o id retornado.
 Resposta: retorna `order` completo (mesmo formato de /details) + `formatContext` + `shareUrl` auto-criado. NAO precisa chamar GET /details apos criar.
 exec(command="curl -s -X POST -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" -H \"Content-Type: application/json\" -d '{\"customerId\":\"abc\",\"services\":[{\"serviceId\":\"srv1\",\"value\":350}]}' \"$PRATICOS_API_URL/bot/orders/full\"")
 
@@ -49,7 +51,7 @@ POST /bot/orders/{NUM}/products `{"productId":"ID","quantity":N,"value":N,"descr
 `description` opcional — texto livre para especificar detalhes. Ver exemplos em SKILL.md regra 5.
 DELETE /bot/orders/{NUM}/services/{I} | DELETE /bot/orders/{NUM}/products/{I}
 PATCH /bot/orders/{NUM}/customer `{"customerId":"ID"}` — corrigir cliente da OS
-PATCH /bot/orders/{NUM}/device `{"deviceId":"ID"}` — corrigir dispositivo da OS
+PATCH /bot/orders/{NUM}/device `{"deviceId":"ID"}` ou `{"device":{"name?","serial?","brand?","model?"}}` — corrigir/definir dispositivo da OS (find-or-create automatico por serial→nome quando inline)
 🔴 **TODOS os endpoints de mutacao** (POST /full, POST/DELETE /services, POST/DELETE /products, PATCH /status, PATCH /:number, PATCH /customer, PATCH /device, POST/DELETE /devices) retornam `{ order, formatContext }` no mesmo formato de /details. Usar dados do response para montar card. NAO re-fetch /details.
 
 ## OS - Dispositivos

--- a/firebase/functions/src/routes/bot/__tests__/orders-management.routes.test.ts
+++ b/firebase/functions/src/routes/bot/__tests__/orders-management.routes.test.ts
@@ -95,6 +95,57 @@ describe('Bot Orders Management Routes', () => {
       expect(res.body.data.formatContext).toBeDefined();
       expect(res.body.data.message).toBeUndefined();
     });
+
+    it('promotes inline device {brand,model,serial} via getOrCreateDevice', async () => {
+      mockCustomerService.getCustomer.mockResolvedValue(fakeCustomer as any);
+      mockDeviceService.getOrCreateDevice = jest.fn().mockResolvedValue({
+        device: { id: 'd-resolved', name: 'Chevrolet Tracker', serial: 'REG9H64' },
+        created: true,
+      });
+      mockDeviceService.getDevice.mockResolvedValue({ id: 'd-resolved', name: 'Chevrolet Tracker', serial: 'REG9H64' } as any);
+      mockOrderService.createOrder.mockResolvedValue({ id: 'ord3', number: 3, status: 'quote' } as any);
+      mockOrderService.getOrderByNumber.mockResolvedValue({ ...fakeOrder, number: 3 } as any);
+      mockShareTokenService.getTokensForOrder.mockResolvedValue([]);
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .post('/full')
+        .send({
+          customerId: 'c1',
+          device: { brand: 'Chevrolet', model: 'Tracker', serial: 'REG9H64' },
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockDeviceService.getOrCreateDevice).toHaveBeenCalledWith(
+        'comp1',
+        'Chevrolet Tracker',
+        'REG9H64',
+        expect.objectContaining({ id: 'user1' }),
+        expect.objectContaining({ id: 'comp1' })
+      );
+      expect(mockDeviceService.getDevice).toHaveBeenCalledWith('comp1', 'd-resolved');
+    });
+
+    it('uses inline device.id directly when provided (legacy path)', async () => {
+      mockCustomerService.getCustomer.mockResolvedValue(fakeCustomer as any);
+      mockDeviceService.getOrCreateDevice = jest.fn();
+      mockDeviceService.getDevice.mockResolvedValue({ id: 'd-existing', name: 'iPhone' } as any);
+      mockOrderService.createOrder.mockResolvedValue({ id: 'ord4', number: 4, status: 'quote' } as any);
+      mockOrderService.getOrderByNumber.mockResolvedValue({ ...fakeOrder, number: 4 } as any);
+      mockShareTokenService.getTokensForOrder.mockResolvedValue([]);
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .post('/full')
+        .send({
+          customerId: 'c1',
+          device: { id: 'd-existing' },
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockDeviceService.getOrCreateDevice).not.toHaveBeenCalled();
+      expect(mockDeviceService.getDevice).toHaveBeenCalledWith('comp1', 'd-existing');
+    });
   });
 
   // ----- POST /:number/services ---------------------------------------------
@@ -205,6 +256,32 @@ describe('Bot Orders Management Routes', () => {
       expect(res.body.data.order.number).toBe(1);
       expect(res.body.data.formatContext).toBeDefined();
       expect(res.body.data.message).toBeUndefined();
+    });
+
+    it('accepts inline device {brand,model,serial} via getOrCreateDevice', async () => {
+      mockDeviceService.getOrCreateDevice = jest.fn().mockResolvedValue({
+        device: { id: 'd-resolved', name: 'Honda HR-V', serial: 'RYW7H55' },
+        created: false,
+      });
+      mockDeviceService.getDevice.mockResolvedValue({ id: 'd-resolved', name: 'Honda HR-V', serial: 'RYW7H55' } as any);
+      mockOrderService.updateOrderDevice.mockResolvedValue({ success: true } as any);
+      mockOrderService.getOrderByNumber.mockResolvedValue(fakeOrder as any);
+      mockShareTokenService.getTokensForOrder.mockResolvedValue([]);
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .patch('/1/device')
+        .send({ device: { brand: 'Honda', model: 'HR-V', serial: 'RYW7H55' } });
+
+      expect(res.status).toBe(200);
+      expect(mockDeviceService.getOrCreateDevice).toHaveBeenCalledWith(
+        'comp1',
+        'Honda HR-V',
+        'RYW7H55',
+        expect.objectContaining({ id: 'user1' }),
+        expect.objectContaining({ id: 'comp1' })
+      );
+      expect(mockDeviceService.getDevice).toHaveBeenCalledWith('comp1', 'd-resolved');
     });
   });
 

--- a/firebase/functions/src/routes/bot/orders-management.routes.ts
+++ b/firebase/functions/src/routes/bot/orders-management.routes.ts
@@ -56,7 +56,33 @@ router.post('/full', requireLinked, async (req: AuthenticatedRequest, res: Respo
     // Normalize common bot field name variations before validation
     const body = { ...req.body };
     if (body.orderId && !body.id) body.id = body.orderId;
-    if (body.device?.id && !body.deviceId) body.deviceId = body.device.id;
+
+    // Inline device → deviceId via find-or-create.
+    // Bot frequently sends `device: { brand, model, serial }` after reading a license plate
+    // from a photo. Without this, the field would be silently dropped and the order
+    // created with no device. See issue #241.
+    if (body.device && !body.deviceId && !body.deviceIds) {
+      const d = body.device;
+      if (d.id) {
+        body.deviceId = d.id;
+      } else {
+        const name: string = (d.name && String(d.name).trim()) ||
+          [d.brand, d.model].filter(Boolean).map(String).map((s) => s.trim()).join(' ').trim();
+        const serial: string | undefined = typeof d.serial === 'string' && d.serial.trim()
+          ? d.serial.trim()
+          : undefined;
+        if (name || serial) {
+          const { device: deviceAggr } = await deviceService.getOrCreateDevice(
+            companyId,
+            name || serial!,
+            serial,
+            getUserAggr(req),
+            getCompanyAggr(req)
+          );
+          body.deviceId = deviceAggr.id;
+        }
+      }
+    }
     delete body.orderId;
     delete body.device;
     delete body.paidAmount; // Not supported on creation, bot sometimes sends it
@@ -735,8 +761,34 @@ router.patch('/:number/device', requireLinked, async (req: AuthenticatedRequest,
       return;
     }
 
+    // Inline device → deviceId via find-or-create. Same fallback as POST /full.
+    const body = { ...req.body };
+    if (body.device && !body.deviceId) {
+      const d = body.device;
+      if (d.id) {
+        body.deviceId = d.id;
+      } else {
+        const name: string = (d.name && String(d.name).trim()) ||
+          [d.brand, d.model].filter(Boolean).map(String).map((s) => s.trim()).join(' ').trim();
+        const serial: string | undefined = typeof d.serial === 'string' && d.serial.trim()
+          ? d.serial.trim()
+          : undefined;
+        if (name || serial) {
+          const { device: deviceAggr } = await deviceService.getOrCreateDevice(
+            companyId,
+            name || serial!,
+            serial,
+            getUserAggr(req),
+            getCompanyAggr(req)
+          );
+          body.deviceId = deviceAggr.id;
+        }
+      }
+      delete body.device;
+    }
+
     // Validate input
-    const validation = validateInput(updateOrderDeviceSchema, req.body);
+    const validation = validateInput(updateOrderDeviceSchema, body);
     if (!validation.success) {
       res.status(400).json({
         success: false,


### PR DESCRIPTION
## Summary

- API agora aceita `device:{name?,brand?,model?,serial?}` inline em `POST /bot/orders/full` e `PATCH /bot/orders/:number/device` — usa `deviceService.getOrCreateDevice()` (find by serial → name → create) para resolver para um id real. Antes o objeto era descartado em silêncio (`delete body.device`), deixando a OS sem veículo vinculado.
- SKILL.md ganhou sub-regra para placa lida de foto + proibição explícita de inventar endpoints (`/update-device`, `/orders/id`). SOUL.md ganhou regra anti-mentira.
- 3 testes novos cobrem: inline `{brand,model,serial}`, inline `{id}` (path legado), e PATCH com inline.

Closes #241

## Test plan

- [x] `npm run build` passa (TypeScript)
- [x] `npx jest src/routes/bot/__tests__/orders-management.routes.test.ts` → 14/14 passando (11 originais + 3 novos)
- [ ] Após deploy do backend: smoke test com curl
  - [ ] `POST /bot/orders/full` com `device:{name:"Chevrolet Tracker",serial:"TST0X99"}` cria device + vincula
  - [ ] Repetir com mesma placa → reutiliza id, não duplica
  - [ ] `PATCH /:NUM/device` com inline em OS órfã → vincula
- [ ] Após `cd backend/bot && make sync` da workspace para a VM:
  - [ ] Mandar foto de placa nova no WhatsApp do bot
  - [ ] Card mostra "Veículo: Marca Modelo (PLACA)" e o app/PDF do PraticOS confirma o vínculo
  - [ ] Logs (`make logs`) sem chamadas a `/update-device` ou `/orders/id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)