### PR TITLE
fix(bot): previne duplicação de OS e vínculo de veículo errado em rajadas de fotos

### DIFF
--- a/backend/bot/workspace/skills/praticos/SKILL.md
+++ b/backend/bot/workspace/skills/praticos/SKILL.md
@@ -79,9 +79,11 @@ message(filePath="/tmp/os-{NUM}.jpg", message="{card}")
    🔴 **PLACA LIDA DE FOTO (segmento automotivo):**
    a) SEMPRE chamar /bot/search/unified com `deviceSerial:"<placa>"` antes de criar a OS.
    b) Se `device.exact` ou `device.suggestions[].serial` bater com a placa → usar `deviceId` desse resultado em /orders/full.
-   c) Se NAO bateu → passar `device:{name:"<Marca Modelo>", serial:"<placa>", brand:"<Marca>", model:"<Modelo>"}` inline em /orders/full. A API resolve via find-or-create automaticamente.
+   c) Se NAO bateu (`exact:null` e `suggestions:[]`) → passar `device:{name:"<Marca Modelo>", serial:"<placa>", brand:"<Marca>", model:"<Modelo>"}` inline em /orders/full. A API resolve via find-or-create automaticamente.
    d) Para corrigir uma OS sem placa: PATCH /bot/orders/{NUM}/device com `{"deviceId":"ID"}` OU `{"device":{...}}` inline. Mesma logica de find-or-create.
-   🔴 NUNCA inventar endpoint para "vincular placa" depois (ex: /update-device, /orders/id, /bot/orders/{NUM}/update-device). Eles NAO existem. Use SOMENTE PATCH /bot/orders/{NUM}/device.
+   e) Para ADICIONAR mais um veiculo a uma OS existente: POST /bot/orders/{NUM}/devices com `{"deviceId":"ID"}` OU `{"device":{...}}` inline (find-or-create igual ao /orders/full).
+   🔴 **`available` NUNCA é match para `deviceSerial`.** Quando a busca foi por placa e veio `exact:null + suggestions:[]`, a API ja retorna `available:null` — nao tem fallback. Se voce ver itens em `available` numa busca por placa, é bug; ignore. **Sempre** use inline `device:{...}` quando nao tem match exato.
+   🔴 NUNCA inventar endpoint para "vincular placa" depois (ex: /update-device, /orders/id, /bot/orders/{NUM}/update-device). Eles NAO existem. Use SOMENTE PATCH /bot/orders/{NUM}/device ou POST /bot/orders/{NUM}/devices.
 3. **CRUD:** buscar primeiro, confirmar editar/excluir. Criar CLIENTE: pedir contato WhatsApp (vCard). ⚠️ Telefone do vCard = dado do CLIENTE (campo `phone`). NUNCA usar como {NUMERO}.
 4. **Fotos:** upload multipart: `curl -s -X POST -H "X-API-Key: $PRATICOS_API_KEY" -H "X-WhatsApp-Number: {NUMERO}" -F "file=@/path/to/photo.jpg" "$PRATICOS_API_URL/bot/orders/{NUM}/photos/upload"`
    Multiplas fotos: uma chamada por foto. Listar: GET /photos. Deletar: DELETE /photos/{ID}.

--- a/backend/bot/workspace/skills/praticos/references/api-endpoints.md
+++ b/backend/bot/workspace/skills/praticos/references/api-endpoints.md
@@ -10,8 +10,9 @@ Exemplo com arrays: {"customer":"Joao","service":["tela","bateria"],"product":["
 Resposta por entidade:
 - customer/device: `{ exact, suggestions, available }` — `exact` = match exato (1 resultado ou null), `suggestions` = matches por nome
 - service/product: `{ results, available }` — `results` = matches encontrados no catalogo
-- `available` (todas): lista de itens cadastrados como fallback (retornado quando sem matches)
+- `available` (todas): lista de itens cadastrados como fallback para buscas POR NOME (retornado quando sem matches)
 🔴 Se `available` tem match similar ao pedido → usar o ID dele + `description` customizada. NAO criar novo.
+🔴 **`available` é SEMPRE `null` quando a busca foi por `deviceSerial` (placa).** Placa é exata: se `device.exact` é `null` e `device.suggestions` está vazio, NAO usar nenhum id de `available` (eles NAO sao matches para a placa). Use inline `device:{name,serial,brand,model}` em /orders/full, PATCH /:number/device ou POST /:number/devices — a API resolve via find-or-create.
 exec(command="curl -s -X POST -H \"X-API-Key: $PRATICOS_API_KEY\" -H \"X-WhatsApp-Number: {NUMERO}\" -H \"Content-Type: application/json\" -d '{\"customer\":\"Joao\",\"service\":[\"tela\",\"bateria\"]}' \"$PRATICOS_API_URL/bot/search/unified\"")
 
 ## Resumo
@@ -55,7 +56,7 @@ PATCH /bot/orders/{NUM}/device `{"deviceId":"ID"}` ou `{"device":{"name?","seria
 🔴 **TODOS os endpoints de mutacao** (POST /full, POST/DELETE /services, POST/DELETE /products, PATCH /status, PATCH /:number, PATCH /customer, PATCH /device, POST/DELETE /devices) retornam `{ order, formatContext }` no mesmo formato de /details. Usar dados do response para montar card. NAO re-fetch /details.
 
 ## OS - Dispositivos
-POST /bot/orders/{NUM}/devices `{"deviceId":"ID"}` — adicionar dispositivo à OS (retorna order detail)
+POST /bot/orders/{NUM}/devices `{"deviceId":"ID"}` OU `{"device":{"name":"Marca Modelo","serial":"PLACA","brand":"Marca","model":"Modelo"}}` — adicionar dispositivo à OS (retorna order detail). Quando passar `device:{...}` inline (sem id), a API faz find-or-create por serial → name. Use isso para placas lidas de foto que nao casam com nada na busca.
 DELETE /bot/orders/{NUM}/devices/{DEVICE_ID} — remover dispositivo da OS (retorna order detail)
 GET /bot/orders/{NUM}/details retorna `devices[]` (lista completa) e `deviceCount` (quantidade)
 

--- a/firebase/functions/src/routes/bot/__tests__/orders-management.routes.test.ts
+++ b/firebase/functions/src/routes/bot/__tests__/orders-management.routes.test.ts
@@ -8,6 +8,24 @@ jest.mock('../../../services/customer.service');
 jest.mock('../../../services/device.service');
 jest.mock('../../../services/catalog.service');
 jest.mock('../../../services/share-token.service');
+jest.mock('../../../services/firestore.service', () => {
+  const actual = jest.requireActual('../../../services/firestore.service');
+  // Stub `db` so the upsert path in POST /full (which calls db.collection().doc().update()
+  // directly instead of going through orderService) doesn't blow up in tests.
+  const stubUpdate = jest.fn().mockResolvedValue(undefined);
+  return {
+    ...actual,
+    db: {
+      collection: () => ({
+        doc: () => ({
+          collection: () => ({
+            doc: () => ({ update: stubUpdate }),
+          }),
+        }),
+      }),
+    },
+  };
+});
 jest.mock('../../../middleware/auth.middleware', () => ({
   requireLinked: (_req: any, _res: any, next: any) => next(),
 }));
@@ -124,6 +142,62 @@ describe('Bot Orders Management Routes', () => {
         expect.objectContaining({ id: 'comp1' })
       );
       expect(mockDeviceService.getDevice).toHaveBeenCalledWith('comp1', 'd-resolved');
+    });
+
+    it('idempotent: reuses recent OS for same customer+createdBy (no id passed)', async () => {
+      // Bot's WhatsApp lane lock can fail on photo bursts → 2nd agent turn
+      // creates a duplicate. Server-side idempotency: if a recent OS exists
+      // for the same customer+createdBy in the last 60s, treat the call as
+      // an update on that OS instead of creating a new one.
+      const recentOrder = { id: 'ord-existing', number: 7, status: 'quote', services: [], products: [] };
+      mockOrderService.findRecentOrderByCustomer = jest.fn().mockResolvedValue(recentOrder as any);
+      mockOrderService.getOrder = jest.fn().mockResolvedValue(recentOrder as any);
+      mockCustomerService.getCustomer.mockResolvedValue(fakeCustomer as any);
+      mockOrderService.getOrderByNumber.mockResolvedValue({ ...fakeOrder, number: 7 } as any);
+      mockShareTokenService.getTokensForOrder.mockResolvedValue([]);
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .post('/full')
+        .send({ customerId: 'c1' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.updated).toBe(true);
+      expect(mockOrderService.findRecentOrderByCustomer).toHaveBeenCalledWith('comp1', 'c1', 'user1');
+      expect(mockOrderService.createOrder).not.toHaveBeenCalled();
+    });
+
+    it('idempotent: creates new OS when no recent match found', async () => {
+      mockOrderService.findRecentOrderByCustomer = jest.fn().mockResolvedValue(null);
+      mockCustomerService.getCustomer.mockResolvedValue(fakeCustomer as any);
+      mockOrderService.createOrder.mockResolvedValue({ id: 'ord-new', number: 8, status: 'quote' } as any);
+      mockOrderService.getOrderByNumber.mockResolvedValue({ ...fakeOrder, number: 8 } as any);
+      mockShareTokenService.getTokensForOrder.mockResolvedValue([]);
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .post('/full')
+        .send({ customerId: 'c1' });
+
+      expect(res.status).toBe(201);
+      expect(mockOrderService.findRecentOrderByCustomer).toHaveBeenCalled();
+      expect(mockOrderService.createOrder).toHaveBeenCalled();
+    });
+
+    it('skips idempotency lookup when explicit id is passed', async () => {
+      mockOrderService.findRecentOrderByCustomer = jest.fn();
+      mockOrderService.getOrder = jest.fn().mockResolvedValue({ id: 'ord-x', number: 9, services: [], products: [] } as any);
+      mockCustomerService.getCustomer.mockResolvedValue(fakeCustomer as any);
+      mockOrderService.getOrderByNumber.mockResolvedValue({ ...fakeOrder, number: 9 } as any);
+      mockShareTokenService.getTokensForOrder.mockResolvedValue([]);
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .post('/full')
+        .send({ customerId: 'c1', id: 'ord-x' });
+
+      expect(res.status).toBe(200);
+      expect(mockOrderService.findRecentOrderByCustomer).not.toHaveBeenCalled();
     });
 
     it('uses inline device.id directly when provided (legacy path)', async () => {
@@ -326,6 +400,36 @@ describe('Bot Orders Management Routes', () => {
       expect(res.body.data.order).toBeDefined();
       expect(res.body.data.formatContext).toBeDefined();
       expect(res.body.data.message).toBeUndefined();
+    });
+
+    it('accepts inline device {brand,model,serial} via getOrCreateDevice', async () => {
+      // Mirror of the PATCH /:number/device fix (eb8cd8de). Without inline
+      // support, the bot would have to resolve a deviceId via search/unified —
+      // but search by plate that doesn't exist yet returns no match, leading
+      // to wrong device IDs being attached.
+      mockDeviceService.getOrCreateDevice = jest.fn().mockResolvedValue({
+        device: { id: 'd-resolved', name: 'Jeep Compass', serial: 'RKZ1J37' },
+        created: true,
+      });
+      mockDeviceService.getDevice.mockResolvedValue({ id: 'd-resolved', name: 'Jeep Compass', serial: 'RKZ1J37' } as any);
+      mockOrderService.addDeviceToOrder.mockResolvedValue({ success: true, devices: [{ id: 'd-resolved' }] } as any);
+      mockOrderService.getOrderByNumber.mockResolvedValue(fakeOrder as any);
+      mockShareTokenService.getTokensForOrder.mockResolvedValue([]);
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .post('/1/devices')
+        .send({ device: { brand: 'Jeep', model: 'Compass', serial: 'RKZ1J37' } });
+
+      expect(res.status).toBe(200);
+      expect(mockDeviceService.getOrCreateDevice).toHaveBeenCalledWith(
+        'comp1',
+        'Jeep Compass',
+        'RKZ1J37',
+        expect.objectContaining({ id: 'user1' }),
+        expect.objectContaining({ id: 'comp1' })
+      );
+      expect(mockDeviceService.getDevice).toHaveBeenCalledWith('comp1', 'd-resolved');
     });
   });
 

--- a/firebase/functions/src/routes/bot/__tests__/unified-search.routes.test.ts
+++ b/firebase/functions/src/routes/bot/__tests__/unified-search.routes.test.ts
@@ -1,0 +1,119 @@
+import request from 'supertest';
+import { buildApp } from './helpers';
+
+// ---- Mocks ----------------------------------------------------------------
+
+jest.mock('../../../services/customer.service');
+jest.mock('../../../services/device.service');
+jest.mock('../../../services/catalog.service');
+jest.mock('../../../middleware/auth.middleware', () => ({
+  requireLinked: (_req: any, _res: any, next: any) => next(),
+}));
+jest.mock('../../../utils/validation.utils', () => {
+  const actual = jest.requireActual('../../../utils/validation.utils');
+  return {
+    ...actual,
+    validateInput: (_schema: any, data: any) => ({ success: true, data }),
+  };
+});
+
+import * as deviceService from '../../../services/device.service';
+import * as customerService from '../../../services/customer.service';
+const mockDeviceService = deviceService as jest.Mocked<typeof deviceService>;
+const mockCustomerService = customerService as jest.Mocked<typeof customerService>;
+
+import router from '../unified-search.routes';
+
+describe('Bot Unified Search Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /unified — deviceSerial', () => {
+    it('returns available:null when search by deviceSerial misses', async () => {
+      // Plate searches are exact-match. When the plate isn't in the catalog,
+      // returning a fallback list of all-devices misled the bot into picking
+      // an unrelated id as if it matched the plate. The bot must use inline
+      // device:{...} (find-or-create) instead.
+      mockDeviceService.findDeviceBySerial.mockResolvedValue(null);
+      // Ensure searchDevices is NOT used as fallback for serial searches
+      mockDeviceService.searchDevices = jest.fn().mockResolvedValue([
+        { id: 'unrelated-1', name: 'Some Other Car', serial: 'XYZ0000' },
+      ]);
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .post('/unified')
+        .send({ deviceSerial: 'RKZ1J37' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.device.exact).toBeNull();
+      expect(res.body.data.device.suggestions).toEqual([]);
+      expect(res.body.data.device.available).toBeNull();
+      // Critical: the all-devices fallback must NOT be invoked for serial searches
+      expect(mockDeviceService.searchDevices).not.toHaveBeenCalledWith('comp1', '', expect.any(Number));
+    });
+
+    it('still returns exact match when serial does match', async () => {
+      mockDeviceService.findDeviceBySerial.mockResolvedValue({
+        id: 'd-match', name: 'Jeep Compass', serial: 'RKZ1J37',
+      } as any);
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .post('/unified')
+        .send({ deviceSerial: 'RKZ1J37' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.device.exact).toEqual({
+        id: 'd-match',
+        name: 'Jeep Compass',
+        serial: 'RKZ1J37',
+      });
+      expect(res.body.data.device.available).toBeNull();
+    });
+
+    it('still returns available fallback for name-based device search', async () => {
+      // Name-based searches keep the available fallback (legitimate UX hint).
+      mockDeviceService.searchDevices = jest.fn(async (_companyId: string, query: string) => {
+        if (query === '') {
+          return [{ id: 'avail-1', name: 'Some Car', serial: 'AAA0001' }] as any;
+        }
+        return [];
+      });
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .post('/unified')
+        .send({ device: 'NonExistent Brand' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.device.exact).toBeNull();
+      expect(res.body.data.device.suggestions).toEqual([]);
+      expect(res.body.data.device.available).toEqual([
+        { id: 'avail-1', name: 'Some Car', serial: 'AAA0001' },
+      ]);
+    });
+  });
+
+  describe('POST /unified — customer', () => {
+    it('available list still returned for customer name search misses', async () => {
+      // Customer search isn't affected by the fix.
+      mockCustomerService.searchCustomers = jest.fn(async (_c: string, query: string) => {
+        if (query === '') {
+          return [{ id: 'cust-1', name: 'Alice', phone: '+5548999990000' }] as any;
+        }
+        return [];
+      });
+
+      const app = buildApp(router);
+      const res = await request(app)
+        .post('/unified')
+        .send({ customer: 'NonExistentName' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.customer.available).toBeTruthy();
+      expect(res.body.data.customer.available.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/firebase/functions/src/routes/bot/orders-management.routes.ts
+++ b/firebase/functions/src/routes/bot/orders-management.routes.ts
@@ -104,6 +104,22 @@ router.post('/full', requireLinked, async (req: AuthenticatedRequest, res: Respo
     const createdBy = getUserAggr(req);
     const company = getCompanyAggr(req);
 
+    // Idempotency: if no explicit id was passed and the bot already created an
+    // OS for the same customer+user in the last 60s, treat this as an update on
+    // that OS. Protects against the WhatsApp multi-photo burst race where the
+    // 2nd agent turn doesn't yet see "OS ativa" in memory and would otherwise
+    // create a duplicate.
+    if (!data.id && createdBy?.id) {
+      const recent = await orderService.findRecentOrderByCustomer(
+        companyId,
+        data.customerId,
+        createdBy.id
+      );
+      if (recent?.id) {
+        data.id = recent.id;
+      }
+    }
+
     // Get customer by ID (required)
     const customer = await customerService.getCustomer(companyId, data.customerId);
     if (!customer) {
@@ -941,7 +957,35 @@ router.post('/:number/devices', requireLinked, async (req: AuthenticatedRequest,
       return;
     }
 
-    const validation = validateInput(addDeviceToOrderSchema, req.body);
+    // Inline device → deviceId via find-or-create. Same fallback as POST /full
+    // and PATCH /:number/device. Keeps the bot's plate-from-photo flow working
+    // when the plate isn't already in the catalog.
+    const body = { ...req.body };
+    if (body.device && !body.deviceId) {
+      const d = body.device;
+      if (d.id) {
+        body.deviceId = d.id;
+      } else {
+        const name: string = (d.name && String(d.name).trim()) ||
+          [d.brand, d.model].filter(Boolean).map(String).map((s) => s.trim()).join(' ').trim();
+        const serial: string | undefined = typeof d.serial === 'string' && d.serial.trim()
+          ? d.serial.trim()
+          : undefined;
+        if (name || serial) {
+          const { device: deviceAggrInline } = await deviceService.getOrCreateDevice(
+            companyId,
+            name || serial!,
+            serial,
+            getUserAggr(req),
+            getCompanyAggr(req)
+          );
+          body.deviceId = deviceAggrInline.id;
+        }
+      }
+      delete body.device;
+    }
+
+    const validation = validateInput(addDeviceToOrderSchema, body);
     if (!validation.success) {
       res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: validation.errors.join(', ') } });
       return;

--- a/firebase/functions/src/routes/bot/unified-search.routes.ts
+++ b/firebase/functions/src/routes/bot/unified-search.routes.ts
@@ -350,7 +350,17 @@ router.post('/unified', requireLinked, async (req: AuthenticatedRequest, res: Re
 
     // Process device results
     if (deviceTerms.length > 0 || data.deviceSerial !== undefined) {
-      const needsFallback = deviceResult && !deviceResult.exact && deviceResult.suggestions.length === 0;
+      // When searching by `deviceSerial` (a license plate / serial), a fallback
+      // list of unrelated devices misled the bot LLM into picking arbitrary
+      // ids as if they matched the plate. Plate searches are exact-match by
+      // nature: when no exact/suggestion match, the bot must use inline
+      // `device:{...}` (find-or-create), not pick from `available`.
+      const queriedBySerial = data.deviceSerial !== undefined;
+      const needsFallback =
+        !queriedBySerial &&
+        deviceResult &&
+        !deviceResult.exact &&
+        deviceResult.suggestions.length === 0;
       response.device = {
         exact: deviceResult?.exact ?? null,
         suggestions: deviceResult?.suggestions ?? [],

--- a/firebase/functions/src/services/order.service.ts
+++ b/firebase/functions/src/services/order.service.ts
@@ -135,6 +135,12 @@ export async function getOrderByNumber(
  * Used by `POST /bot/orders/full` to dedupe rapid-fire creations (e.g. when two
  * WhatsApp photos arrive in the same burst before the bot's "OS ativa" memory
  * write completes).
+ *
+ * Index reuse: Firestore query uses only `(customer.id ==, createdAt >=)`,
+ * covered by the existing composite index `(customer.id ASC, createdAt DESC)`
+ * in firestore.indexes.json. The `createdBy.id` match is post-filtered in
+ * memory to avoid requiring a new 3-field composite index. The limit(5) margin
+ * is plenty since a single customer rarely gets >1 OS per minute.
  */
 export async function findRecentOrderByCustomer(
   companyId: string,
@@ -146,19 +152,20 @@ export async function findRecentOrderByCustomer(
   const sinceIso = new Date(Date.now() - sinceMs).toISOString();
   const snapshot = await collection
     .where('customer.id', '==', customerId)
-    .where('createdBy.id', '==', createdById)
     .where('createdAt', '>=', sinceIso)
     .orderBy('createdAt', 'desc')
-    .limit(1)
+    .limit(5)
     .get();
 
   if (snapshot.empty) return null;
 
-  const doc = snapshot.docs[0];
-  return {
-    ...doc.data(),
-    id: doc.id,
-  } as Order;
+  for (const doc of snapshot.docs) {
+    const data = doc.data() as Order & { createdBy?: { id?: string } };
+    if (data.createdBy?.id === createdById) {
+      return { ...data, id: doc.id } as Order;
+    }
+  }
+  return null;
 }
 
 /**

--- a/firebase/functions/src/services/order.service.ts
+++ b/firebase/functions/src/services/order.service.ts
@@ -129,6 +129,39 @@ export async function getOrderByNumber(
 }
 
 /**
+ * Find the most recent order created by `createdById` for `customerId` within
+ * the time window. Returns null if none.
+ *
+ * Used by `POST /bot/orders/full` to dedupe rapid-fire creations (e.g. when two
+ * WhatsApp photos arrive in the same burst before the bot's "OS ativa" memory
+ * write completes).
+ */
+export async function findRecentOrderByCustomer(
+  companyId: string,
+  customerId: string,
+  createdById: string,
+  sinceMs: number = 60_000
+): Promise<Order | null> {
+  const collection = getTenantCollection(companyId, 'orders');
+  const sinceIso = new Date(Date.now() - sinceMs).toISOString();
+  const snapshot = await collection
+    .where('customer.id', '==', customerId)
+    .where('createdBy.id', '==', createdById)
+    .where('createdAt', '>=', sinceIso)
+    .orderBy('createdAt', 'desc')
+    .limit(1)
+    .get();
+
+  if (snapshot.empty) return null;
+
+  const doc = snapshot.docs[0];
+  return {
+    ...doc.data(),
+    id: doc.id,
+  } as Order;
+}
+
+/**
  * Get orders by status
  */
 export async function getOrdersByStatus(


### PR DESCRIPTION
## Summary

Dois bugs reportados pelo usuário ao enviar múltiplas fotos em sequência para criar uma OS via WhatsApp bot:

1. **OS duplicada**: quando 2+ fotos chegam em poucos segundos, o bot cria uma OS por foto. Race window entre criação da OS e gravação de "OS ativa" na memória do bot. Reproduzido em prod: EH Climatização #104 (vazia) + #105 (cheia), 35s de diferença, mesmo cliente.
2. **Veículo errado vinculado**: ao ler placa de foto que ainda não existe no catálogo, `/bot/search/unified` retornava `available:[<todos os veículos da empresa>]`. O LLM pegava o primeiro id (não relacionado à placa) e mandava `POST /:number/devices` com `deviceId` errado. Visto na sessão do Manoel/Maneca: placa RKZ1J37 (Jeep Compass) foi anexada como Peugeot 3008/QJC5496.

## Mudanças (defesa em camadas)

**API** — `firebase/functions/src/routes/bot/orders-management.routes.ts`:
- `POST /orders/full` agora faz idempotency lookup antes de criar — se há OS recente para o mesmo `customer.id + createdBy.id` em janela de 60s e não veio `id` explícito, faz upsert na existente. Bot não precisa mudar.
- `POST /:number/devices` agora aceita `device:{name,serial,brand,model}` inline (espelha o fix de `PATCH /:number/device` em #242). Dá ao bot caminho válido para anexar veículo recém-lido de foto.

**API** — `firebase/functions/src/routes/bot/unified-search.routes.ts`:
- Quando a busca tem `deviceSerial`, não retorna mais `available` (lista fallback de todos os veículos). Placa é exata; fallback enganava o LLM. Buscas por nome continuam com `available`.

**API** — `firebase/functions/src/services/order.service.ts`:
- Novo helper `findRecentOrderByCustomer(companyId, customerId, createdById, sinceMs=60_000)` usado pela idempotência.

**Bot prompt** — `backend/bot/workspace/skills/praticos/`:
- `SKILL.md`: regra "PLACA LIDA DE FOTO" reforçada — explícito que `available` NUNCA é match para `deviceSerial`; sempre usar inline device quando não há match exato.
- `references/api-endpoints.md`: documenta inline em `POST /:number/devices` e clarifica `available:null` em buscas por serial.

## Test plan

- [x] Testes adicionados:
  - 4 testes de idempotência em `POST /orders/full` (reusa OS recente, cria nova fora da janela, pula lookup se `id` explícito, inline device segue funcionando)
  - 1 teste para `POST /:number/devices` aceitando inline device
  - 3 testes para `unified-search`: serial miss → `available:null`, serial match ainda funciona, name search mantém fallback
- [x] `npx jest src/routes/bot/__tests__/orders-management.routes.test.ts src/routes/bot/__tests__/unified-search.routes.test.ts` → 22/22 passando
- [x] `npx tsc --noEmit` → limpo
- [ ] Deploy: `cd firebase/functions && firebase deploy --only functions:api`
- [ ] Deploy bot skill: `cd backend/bot && make sync`
- [ ] E2E manual no bot dev: 2 fotos do mesmo carro em <2s → 1 OS criada (não 2)
- [ ] E2E manual: foto com placa nova → OS recebe veículo com aquela placa exata

## Observações

- Os 7 testes que falham na suite completa (`analytics`, `summary`, `catalog`, `orders.routes`) já falhavam em master — não relacionados a esta mudança.
- Branch é construída em cima do PR #242 (já merjado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)